### PR TITLE
root README: fix template, add Geschwurbel, publish to gh-pages

### DIFF
--- a/.ci/github/_dep_gomplate.sh
+++ b/.ci/github/_dep_gomplate.sh
@@ -1,0 +1,8 @@
+#/bin/bash
+
+set -e
+
+readonly TARGETDIR=$GITHUB_WORKSPACE/bin
+readonly GOMPLATE_VERSION="3.7.0"
+
+curl -L -o $TARGETDIR/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64 && chmod +x $TARGETDIR/gomplate

--- a/.ci/github/_dep_helm-docs.sh
+++ b/.ci/github/_dep_helm-docs.sh
@@ -1,0 +1,8 @@
+#/bin/bash
+
+set -e
+
+readonly TARGETDIR=$GITHUB_WORKSPACE/bin
+readonly HELM_DOCS_VERSION="0.12.0"
+
+curl -L -o - https://github.com/norwoodj/helm-docs/releases/download/v$HELM_DOCS_VERSION/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz | tar -C $TARGETDIR -zxf -

--- a/.ci/github/install-releaser-deps.sh
+++ b/.ci/github/install-releaser-deps.sh
@@ -6,7 +6,6 @@ readonly TARGETDIR=$GITHUB_WORKSPACE/bin
 
 mkdir -p $TARGETDIR
 
-.ci/github/_dep_helm-docs.sh
 .ci/github/_dep_gomplate.sh
 
 echo "::add-path::$TARGETDIR"

--- a/.ci/github/update-pages-site.sh
+++ b/.ci/github/update-pages-site.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+
+echo 'Updating charts repo site...'
+
+set -ex
+
+gh_pages_worktree=$(mktemp -d)
+
+git worktree add "$gh_pages_worktree" gh-pages
+
+HELMCHARTS_GOMPLATE_OUTPUT="$gh_pages_worktree/index.md" \
+HELMCHARTS_GOMPLATE_NAME=indexpage \
+./hack/update-readme.sh
+
+mkdir --parent "$gh_pages_worktree/docs/images"
+cp --force docs/images/lunkwill_helm_shirt.png "$gh_pages_worktree/docs/images/lunkwill_helm_shirt.png"
+
+pushd "$gh_pages_worktree" > /dev/null
+
+git add index.md docs/images/lunkwill_helm_shirt.png
+git commit --message="Update site" --signoff
+
+local repo_url="https://x-access-token:$CR_TOKEN@github.com/adfinis-sygroup/helm-charts"
+git push "$repo_url" gh-pages
+
+popd > /dev/null

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
+      - name: Install deps
+        run: .ci/github/install-release-deps.sh
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -22,5 +25,10 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-rc.2
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+
+      - name: Update Pages site
+        run: .ci/github/update-pages-site.sh
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Adfinis Helm Charts
 
 ![Release Charts](https://github.com/adfinis-sygroup/helm-charts/workflows/Release%20Charts/badge.svg)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 ![Lunkwill wearing a Helm shirt](docs/images/lunkwill_helm_shirt.png)
 
-This repository contains [Helm](https://helm.sh/) charts managed by [Adfinis](https://adfinis.com).
+This repository contains [Helm](https://helm.sh/) charts managed by [Adfinis](https://adfinis.com/?pk_campaign=github&pk_kwd=helm-charts).
 
 ## Usage
 
@@ -16,13 +17,14 @@ helm repo add adfinis https://charts.adfinis.com
 
 ### Available Helm charts
 
-| Chart | Description |
-| ----- | ----------- |
-| [argoconfig](charts/argoconfig) | Configure an Argo CD AppProject and Application |
-| [barman](charts/barman) | Chart for Barman PostgreSQL Backup and Recovery Manager |
-| [caasperli](charts/caasperli) | Deploy Caasperli to a Kubernetes Cluster |
-| [kasperleyn](charts/kasperleyn) | A Helm 2 chart to deploy Caasperli |
-| [timed](charts/timed) | Chart for Timed application |
+#### more charts
+| Chart | Description | Chart Version | App Version |
+| ----- | ----------- | ------------- | ----------- |
+| [argoconfig](charts/argoconfig) | Configure an Argo CD AppProject and Application | `0.x` | `latest` |
+| [barman](charts/barman) | Chart for Barman PostgreSQL Backup and Recovery Manager | `0.x` | `2.1.x` |
+| [caasperli](charts/caasperli) | Deploy Caasperli to a Kubernetes Cluster | `0.x` | `latest` |
+| [kasperleyn](charts/kasperleyn) | A Helm 2 chart to deploy Caasperli | `0.x` | `1.0.x` |
+| [timed](charts/timed) | Chart for Timed application | `0.x` | `0.x` |
 
 ## Development
 
@@ -44,6 +46,14 @@ After installing the pre-commit requirements you can initialize pre-commit.
 pre-commit install
 pre-commit install-hooks
 ```
+
+## About this repository
+
+Adfinis fights for a software world that is more open, where the quality is
+better and where software must be accessible to everyone. This repository
+contains part of the action behind this comitment. Feel free to
+[contact](https://adfinis.com/kontakt/?pk_campaign=github&pk_kwd=helm-charts)
+us if you have any questions.
 
 ## License
 

--- a/hack/README.tpl.md
+++ b/hack/README.tpl.md
@@ -1,10 +1,33 @@
 # Adfinis Helm Charts
+{{- $readme := (ds "readme") -}}
+{{- define "helmcharts.shortVersion" -}}
+  {{/*
+    helmcharts.shortVersion template generates human readable generalized version strings.
+
+    Given the input "0.1.2" is will generate "0.x", given "1.2.3" it will generate "1.2.x" and to on.
+  */}}
+  {{- $version := . | conv.ToString | strings.TrimPrefix "v" -}}
+  {{- if eq $version "latest" -}}
+    {{/* ignore latest version when shortening */}}
+    {{- $version -}}
+  {{- else -}}
+    {{/* output important part of version and trailing .x */}}
+    {{- $targetParts := 1 -}}
+    {{- if not ($version | strings.HasPrefix "0") -}}
+      {{/* handle production version (ie. not starting with 0) */}}
+      {{- $targetParts = 2 -}}
+    {{- end -}}
+    {{- $shortLen := add ($version | strings.SplitN "." $targetParts | len) (sub $targetParts 1) | conv.ToInt -}}
+    {{- strings.Trunc $shortLen $version }}.x
+  {{- end -}}
+{{- end }}
 
 ![Release Charts](https://github.com/adfinis-sygroup/helm-charts/workflows/Release%20Charts/badge.svg)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 ![Lunkwill wearing a Helm shirt](docs/images/lunkwill_helm_shirt.png)
 
-This repository contains [Helm](https://helm.sh/) charts managed by [Adfinis](https://adfinis.com).
+This repository contains [Helm](https://helm.sh/) charts managed by [Adfinis](https://adfinis.com/?pk_campaign=github&pk_kwd=helm-charts).
 
 ## Usage
 
@@ -15,17 +38,36 @@ helm repo add adfinis https://charts.adfinis.com
 ```
 
 ### Available Helm charts
+{{- range (file.ReadDir "charts/" | sort) -}}
+{{- $chartManifestPath := print "charts/" . "/Chart.yaml" -}}
+{{- if (file.Exists $chartManifestPath) -}}{{- $chartManifest := file.Read $chartManifestPath | data.YAML -}}
+{{- if has $chartManifest "icon" }}
+#### [{{.}}]({{ print $readme.chartBaseURL . }})
 
-| Chart | Description |
-| ----- | ----------- |
-{{- range (file.ReadDir "charts/" | sort) }}
-{{- $chartManifestPath := print "charts/" . "/Chart.yaml" }}
-{{ if (file.Exists $chartManifestPath) -}}
-    {{- $chartManifest := file.Read $chartManifestPath | data.YAML -}}
-| [{{.}}]({{print "charts/" .}}) | {{ $chartManifest.description }} |
-{{- end }}
+![Version: {{ template "helmcharts.shortVersion" $chartManifest.version }}](https://img.shields.io/badge/version-{{ template "helmcharts.shortVersion" $chartManifest.version }}-brightgreen)
+![App version: {{ template "helmcharts.shortVersion" $chartManifest.appVersion }}](https://img.shields.io/badge/app%20version-{{ template "helmcharts.shortVersion" $chartManifest.appVersion }}-brightgreen)
+
+{{ $chartManifest.description }}
+
+[![{{.}}]({{ $chartManifest.icon }})]({{ print $readme.chartBaseURL . }})
+{{- end -}}
+{{- end -}}
 {{- end }}
 
+#### more charts
+| Chart | Description | Chart Version | App Version |
+| ----- | ----------- | ------------- | ----------- |
+{{- range (file.ReadDir "charts/" | sort) -}}
+{{- $chartManifestPath := print "charts/" . "/Chart.yaml" -}}
+{{- if (file.Exists $chartManifestPath) -}}{{- $chartManifest := file.Read $chartManifestPath | data.YAML -}}
+{{- if not (has $chartManifest "icon") }}
+| [{{.}}]({{ print $readme.chartBaseURL . }}) | {{ $chartManifest.description | strings.Abbrev 80 }} | `{{ template "helmcharts.shortVersion" $chartManifest.version }}` | `{{ template "helmcharts.shortVersion" $chartManifest.appVersion }}` |
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- if not $readme.web.enabled }}
+{{/* This content only shows up on the GitHUb README and not on charts.adfinis.com */}}
 ## Development
 
 ### pre-commit hook
@@ -46,6 +88,23 @@ After installing the pre-commit requirements you can initialize pre-commit.
 pre-commit install
 pre-commit install-hooks
 ```
+{{- else }}
+{{/* This content replaces the Development section when used as index page */}}
+## Contributing
+
+This Helm chart repositories code may be found on [GitHub](https://github.com) at
+[adfinis-sygroup/helm-charts](https://github.com/adfinis-sygroup/helm-charts).
+
+We track issues with this chart repository in the [issue tracker](https://github.com/adfinis-sygroup/helm-charts/issues).
+{{- end }}
+
+## About this repository
+
+Adfinis fights for a software world that is more open, where the quality is
+better and where software must be accessible to everyone. This repository
+contains part of the action behind this comitment. Feel free to
+[contact](https://adfinis.com/kontakt/?pk_campaign=github&pk_kwd=helm-charts)
+us if you have any questions.
 
 ## License
 

--- a/hack/update-readme.sh
+++ b/hack/update-readme.sh
@@ -9,7 +9,13 @@ err () {
     exit 1
 }
 
+# specify an alternative hack/update-readme/$HELMCHARTS_GOMPLATE_NAME.yaml config
+readonly readme_config_name=${HELMCHARTS_GOMPLATE_NAME:-readme}
+# where to render the template to, defaults to README.md but can be overridden for generating the GitHub Pages index
+readonly output_path=${HELMCHARTS_GOMPLATE_OUTPUT:-README.md}
+
 [[ ! -x `which helm` ]] && err "Could not locate helm binary. See https://helm.sh/docs/intro/install/ for info."
 [[ ! -x `which gomplate` ]] && err "Could not locate gomplate binary. See https://docs.gomplate.ca/installing/ for info."
 
-gomplate -o README.md -f hack/README.tpl.md
+gomplate -o $output_path -f hack/README.tpl.md \
+  -d readme=hack/update-readme/$readme_config_name.yaml

--- a/hack/update-readme/indexpage.yaml
+++ b/hack/update-readme/indexpage.yaml
@@ -1,0 +1,4 @@
+web:
+  enabled: true
+
+chartBaseURL: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/

--- a/hack/update-readme/readme.yaml
+++ b/hack/update-readme/readme.yaml
@@ -1,0 +1,4 @@
+web:
+  enabled: false
+
+chartBaseURL: "charts/"


### PR DESCRIPTION
* fixes some issues with the existing template
* exposes current versions of charts and apps in README
* uses gomplate to update the GitHub Pages site
* adds matomo campaign trackers for links to adfinis.com
* adds some marketing speak and a contact link to the readme
* cleans up `.ci/github` for more reuseability
