### PR TITLE
argoconfig: helper for creating cluster secrets

### DIFF
--- a/charts/argoconfig/Chart.yaml
+++ b/charts/argoconfig/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argoconfig
 description: Configure an Argo CD AppProject and Application
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: latest
 home: https://github.com/adfinis-sygroup/helm-charts
 maintainers:

--- a/charts/argoconfig/README.md
+++ b/charts/argoconfig/README.md
@@ -2,7 +2,7 @@ argoconfig
 ==========
 Configure an Argo CD AppProject and Application
 
-Current chart version is `0.2.0`
+Current chart version is `0.3.0`
 
 Source code can be found [here](https://github.com/adfinis-sygroup/helm-charts)
 
@@ -28,5 +28,9 @@ Source code can be found [here](https://github.com/adfinis-sygroup/helm-charts)
 | application.source.repoURL | string | `""` | URL of sourece repo |
 | application.source.targetRevision | string | `"*"` | Revision of chart in source repo to install |
 | application.syncPolicy | object | deactivated | Application [Sync Policy](https://argoproj.github.io/argo-cd/user-guide/auto_sync/) |
+| cluster.clusterNameOverride | string | `nil` | Override name of the cluster |
+| cluster.config | object | `{}` | Cluster config (ie. contents of a KUBECONFIG) |
+| cluster.enabled | bool | `false` | Create a cluster config secret |
+| cluster.server | string | `"https://kubernetes.default.svc"` | Cluster URL used by Argo CD to connect to the cluster |
 | fullnameOverride | string | `""` | Override fullname |
 | nameOverride | string | `""` | Override names |

--- a/charts/argoconfig/ci/default.yaml
+++ b/charts/argoconfig/ci/default.yaml
@@ -1,0 +1,2 @@
+cluster:
+  enabled: true

--- a/charts/argoconfig/templates/secret-cluster.yaml
+++ b/charts/argoconfig/templates/secret-cluster.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.cluster.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "argoconfig.fullname" . }}
+  namespace: {{ .Values.application.namespace }}
+  labels:
+    {{- include "argoconfig.labels" . | nindent 4 }}
+    argocd.argoproj.io/secret-type: cluster
+type: Opaque
+stringData:
+  {{- if .Values.cluster.clusterNameOverride }}
+  name: {{ .Values.cluster.clusterNameOverride }}
+  {{- else }}
+  name: {{ include "argoconfig.fullname" . }}
+  {{- end }}
+  server: {{ .Values.cluster.server }}
+  config: |
+    {{- .Values.cluster.config | toJson | nindent 4 -}}
+{{- end -}}

--- a/charts/argoconfig/values.yaml
+++ b/charts/argoconfig/values.yaml
@@ -51,3 +51,13 @@ application:
   # application.syncPolicy -- Application [Sync Policy](https://argoproj.github.io/argo-cd/user-guide/auto_sync/)
   # @default -- deactivated
   syncPolicy: {}
+
+cluster:
+  # cluster.enabled -- Create a cluster config secret
+  enabled: false
+  # cluster.clusterNameOverride -- Override name of the cluster
+  clusterNameOverride: ~
+  # cluster.server -- Cluster URL used by Argo CD to connect to the cluster
+  server: https://kubernetes.default.svc
+  # cluster.config -- Cluster config (ie. contents of a KUBECONFIG)
+  config: {}


### PR DESCRIPTION
This new template helps you create the [cluster parts of a declarative argoconfig setup](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#clusters).