### PR TITLE
implement rbac for automatic restore of postgresql databases

### DIFF
--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: barman
 type: application
 description: Chart for Barman PostgreSQL Backup and Recovery Manager
-version: 0.0.4
+version: 0.0.5
 appVersion: 2.1
 keywords:
   - barman

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -2,7 +2,7 @@ barman
 ======
 Chart for Barman PostgreSQL Backup and Recovery Manager
 
-Current chart version is `0.0.4`
+Current chart version is `0.0.5`
 
 
 **Homepage:** <http://www.pgbarman.org/>
@@ -31,6 +31,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | `barman.backups[0].backupMethod` | string | `"postgres"` | Barman backup method |
 | `barman.backups[0].databaseSlotName` | string | `"barman"` | Database slot name to be created/used |
 | `barman.backups[0].lastBackupMaximumAge` | string | `"1 day"` | Barman last backup maximum age |
+| `barman.backups[0].namespace` | string | `"postgresql"` | namespace where postgresql is deployed |
 | `barman.backups[0].postgresql.host` | string | `"postgresql"` | Postgresql host |
 | `barman.backups[0].postgresql.port` | int | `5432` | Postgresql port |
 | `barman.backups[0].postgresql.replicationPassword` | string | `"barman"` | Postgresql replication password |
@@ -39,6 +40,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | `barman.backups[0].postgresql.superUserDatabase` | string | `"postgres"` | Postgresql super user database |
 | `barman.backups[0].postgresql.superUserPassword` | string | `"postgres"` | Postgresql super user password |
 | `barman.backups[0].retentionPolicy` | string | `"RECOVERY WINDOW of 1 MONTH"` | Barman retention policy |
+| `barman.backups[0].serviceaccount` | string | `"postgresql"` | service account of the postgresql deployment |
 | `barman.barmanUser` | string | `"barman"` | Barman user |
 | `barman.compression` | string | `"gzip"` | Barman backup compression |
 | `barman.databaseSlotName` | string | `"barman"` | Database slot name to be created/used |
@@ -64,6 +66,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | `prometheus.serviceMonitor.interval` | string | `"30s"` | Interval at which metrics should be scraped |
 | `prometheus.serviceMonitor.metricRelabelings` | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
 | `prometheus.serviceMonitor.relabelings` | list | `[]` | RelabelConfigs to apply to samples before scraping |
+| `rbac.create` | bool | `false` | Whether to create RBAC or not |
 | `resources` | object | `{}` | Resource limits and requests |
 
 ## About this chart

--- a/charts/barman/templates/clusterrole.yaml
+++ b/charts/barman/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: barman-backup
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+{{- end }}

--- a/charts/barman/templates/rolebinding.yaml
+++ b/charts/barman/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: postgresqlbarman
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: barman-backup
+subjects:
+{{- range .Values.barman.backups }}
+- kind: ServiceAccount
+  name: {{ .serviceaccount }}
+  namespace: {{ .namespace }}
+{{- end }}
+{{- end }}

--- a/charts/barman/values.yaml
+++ b/charts/barman/values.yaml
@@ -29,6 +29,10 @@ persistence:
     # persistence.recover.storageClass -- Storage class
     storageClass: ""
 
+rbac:
+  # rbac.create -- Whether to create RBAC or not
+  create: false
+
 barman:
   # barman.backupMethod -- Barman backup method
   backupMethod: postgres
@@ -73,6 +77,13 @@ barman:
         replicationUser: barman
         # barman.backups[0].postgresql.replicationPassword -- Postgresql replication password
         replicationPassword: barman
+      # barman.backups[0].namespace -- namespace where postgresql is deployed
+      ## not active when barman.createRbac is false
+      namespace: postgresql
+      # barman.backups[0].serviceaccount -- service account of the postgresql deployment
+      ## not active when barman.createRbac is false
+      serviceaccount: postgresql
+
 
 prometheus:
   # prometheus.enabled -- Enable Prometheus integration


### PR DESCRIPTION
This let's a user create a ClusterRole to automatically restore postgresql database if a backup is available.

Example initContainer for use in the `bitnami/postgresql` chart:

```yaml
barman:
  containerName: barman-barman-0
  namespace: backup-barman

master:
  extraInitContainers:
  - name: barman-restore
    image: bitnami/kubectl
    command:
    - /bin/bash
    - -cx
    - |
      set -euf
      [ "$(ls -A /data/data)" ] && exit 0 || echo "data dir is empty. trying to restore latest backup"
      [ "$(kubectl --namespace {{ .Values.barman.namespace }} get pod {{ .Values.barman.containerName }})" ] || exit 0
      [ "$(kubectl --namespace {{ .Values.barman.namespace }} exec {{ .Values.barman.containerName }} -- barman check-backup {{ template "postgresql.name" . }} last)" ] || exit 0
      kubectl --namespace {{ .Values.barman.namespace }} exec {{ .Values.barman.containerName }} -- barman recover {{ template "postgresql.name" . }} last /var/lib/barman/recover/{{ template "postgresql.name" . }}
      kubectl --namespace {{ .Values.barman.namespace }} cp {{ .Values.barman.containerName }}:/var/lib/barman/recover/{{ template "postgresql.name" . }} /data/data
    volumeMounts:
      - name: data
        mountPath: /data
```