### PR TITLE
:rewind: (barman) default Retain policy for data volume

### DIFF
--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: barman
 type: application
 description: Chart for Barman PostgreSQL Backup and Recovery Manager
-version: 0.0.6
+version: 0.0.7
 appVersion: 2.1
 keywords:
   - barman

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -2,7 +2,7 @@ barman
 ======
 Chart for Barman PostgreSQL Backup and Recovery Manager
 
-Current chart version is `0.0.6`
+Current chart version is `0.0.7`
 
 
 **Homepage:** <http://www.pgbarman.org/>
@@ -51,7 +51,6 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | `image.tag` | string | `"latest"` | Image tag |
 | `persistence.data.accessMode` | string | `"ReadWriteOnce"` | Access mode for persistent storage |
 | `persistence.data.enabled` | bool | `true` | Enable persistent storage for backup data |
-| `persistence.data.persistentVolumeReclaimPolicy` | string | `"Retain"` | PV reclaim policy |
 | `persistence.data.size` | string | `"20Gi"` | Size of storage volume |
 | `persistence.data.storageClass` | string | `""` | Storage class |
 | `persistence.recover.accessMode` | string | `"ReadWriteOnce"` | Access mode for persistent storage |

--- a/charts/barman/ci/default-values.yaml
+++ b/charts/barman/ci/default-values.yaml
@@ -1,3 +1,0 @@
-persistence:
-  data:
-    enabled: false

--- a/charts/barman/templates/statefulset.yaml
+++ b/charts/barman/templates/statefulset.yaml
@@ -103,7 +103,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.data.size | quote }}
-        persistentVolumeReclaimPolicy: {{ .Values.persistence.data.persistentVolumeReclaimPolicy | quote }}
     {{- end }}
     {{- if .Values.persistence.recover.enabled }}
     - metadata:

--- a/charts/barman/values.yaml
+++ b/charts/barman/values.yaml
@@ -19,8 +19,6 @@ persistence:
     size: 20Gi
     # persistence.data.storageClass -- Storage class
     storageClass: ""
-    # persistence.data.persistentVolumeReclaimPolicy -- PV reclaim policy
-    persistentVolumeReclaimPolicy: Retain
   recover:
     # persistence.recover.enabled -- Enable persistent storage for recovery
     enabled: false


### PR DESCRIPTION
The `persistentVolumeReclaimPolicy` can only be set on a PV (or defaulted on the StorageClass itself). I'm not sure how to properly fix this, but this revert at least make the latest version of the chart not fail. I'll have a look at the possibility of setting this through an annotation or with a dedicated StorageClass but I don't think either of those solutions are the way to go (see https://github.com/kubernetes/kubernetes/issues/30606 for some discussion about this).

This reverts commit 1379c2f0fc60d17ef1e25e696d1c6daf8a97fc5e.