### PR TITLE
feat(sentry-apps): bump Sentry Helm chart to 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ helm repo add adfinis https://charts.adfinis.com
 | [caasperli](charts/caasperli) | Deploy Caasperli to a Kubernetes Cluster | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: latest](https://img.shields.io/badge/app%20version-latest-brightgreen) |
 | [common](charts/common) | Common chartbuilding components and helpers, based on incubator/common | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 0.x](https://img.shields.io/badge/app%20version-0.x-brightgreen) |
 | [kasperleyn](charts/kasperleyn) | A Helm 2 chart to deploy Caasperli | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 1.0.x](https://img.shields.io/badge/app%20version-1.0.x-brightgreen) |
-| [sentry-apps](charts/sentry-apps) | Sentry on premise | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 4.7.x](https://img.shields.io/badge/app%20version-4.7.x-brightgreen) |
+| [sentry-apps](charts/sentry-apps) | Sentry on premise | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 5.0.x](https://img.shields.io/badge/app%20version-5.0.x-brightgreen) |
 | [timed](charts/timed) | Chart for Timed application | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 1.1.x](https://img.shields.io/badge/app%20version-1.1.x-brightgreen) |
 
 ## Contributing

--- a/charts/sentry-apps/Chart.yaml
+++ b/charts/sentry-apps/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry-apps
 description: Sentry on premise
 type: application
-version: 0.1.1
-appVersion: 4.7.2
+version: 0.2.0
+appVersion: 5.0.0
 home: https://github.com/sentry-kubernetes/charts/tree/develop/sentry
 sources:
   - https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/sentry-apps

--- a/charts/sentry-apps/README.md
+++ b/charts/sentry-apps/README.md
@@ -2,7 +2,7 @@ sentry-apps
 ===========
 Sentry on premise
 
-Current chart version is `0.1.1`
+Current chart version is `0.2.0`
 
 
 **Homepage:** <https://github.com/sentry-kubernetes/charts/tree/develop/sentry>
@@ -37,6 +37,8 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | `kafka.replicaCount` | int | `1` | number of Kakfa brokers to deploy |
 | `kafka.transactionStateLogMinIsr` | int | `1` | overridden min.insync.replicas config for the transaction topic |
 | `kafka.transactionStateLogReplicationFactor` | int | `1` | replication factor for the transaction topic |
+| `nginx` | object | See [sentry's default](https://github.com/sentry-kubernetes/charts/blob/develop/sentry/values.yaml) | NGINX configuration (required when `ingress.enabled=false`) |
+| `nginx.enabled` | bool | `true` | enables nginx |
 | `postgresql.postgresqlPassword` | string | `nil` | password used to access the database |
 | `rabbitmq.enabled` | bool | `false` | enable RabbitMQ Redis will be used instead. |
 | `redis` | object | See [bitnami/redis](https://github.com/bitnami/charts/tree/master/bitnami/redis) chart | Redis settigs |

--- a/charts/sentry-apps/templates/application.yaml
+++ b/charts/sentry-apps/templates/application.yaml
@@ -40,6 +40,9 @@ spec:
         kafka:
           {{- .Values.kafka | toYaml | nindent 10 }}
 
+        nginx:
+          {{- .Values.nginx | toYaml | nindent 10 }}
+
         postgresql:
           postgresqlPassword: {{ .Values.postgresql.postgresqlPassword | quote }}
           persistence:

--- a/charts/sentry-apps/values.yaml
+++ b/charts/sentry-apps/values.yaml
@@ -53,6 +53,12 @@ kafka:
   # kafka.transactionStateLogMinIsr -- overridden min.insync.replicas config for the transaction topic
   transactionStateLogMinIsr: 1
 
+  # nginx -- NGINX configuration (required when `ingress.enabled=false`)
+# @default -- See [sentry's default](https://github.com/sentry-kubernetes/charts/blob/develop/sentry/values.yaml)
+nginx:
+  # nginx.enabled -- enables nginx
+  enabled: true
+
 rabbitmq:
   # rabbitmq.enabled -- enable RabbitMQ
   # Redis will be used instead.

--- a/charts/sentry-apps/values.yaml
+++ b/charts/sentry-apps/values.yaml
@@ -53,7 +53,7 @@ kafka:
   # kafka.transactionStateLogMinIsr -- overridden min.insync.replicas config for the transaction topic
   transactionStateLogMinIsr: 1
 
-  # nginx -- NGINX configuration (required when `ingress.enabled=false`)
+# nginx -- NGINX configuration (required when `ingress.enabled=false`)
 # @default -- See [sentry's default](https://github.com/sentry-kubernetes/charts/blob/develop/sentry/values.yaml)
 nginx:
   # nginx.enabled -- enables nginx


### PR DESCRIPTION
- 5.0.0 (Sentry 20.7.2) adds Relay to the mix.
- enables NGINX by default, which has to be disabled when using Ingress.