### PR TITLE
:arrow_up: (sentry-apps) bump sentry-kubernetes/sentry to 5.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ helm repo add adfinis https://charts.adfinis.com
 | [caasperli](charts/caasperli) | Deploy Caasperli to a Kubernetes Cluster | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: latest](https://img.shields.io/badge/app%20version-latest-brightgreen) |
 | [common](charts/common) | Common chartbuilding components and helpers, based on incubator/common | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 0.x](https://img.shields.io/badge/app%20version-0.x-brightgreen) |
 | [kasperleyn](charts/kasperleyn) | A Helm 2 chart to deploy Caasperli | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 1.0.x](https://img.shields.io/badge/app%20version-1.0.x-brightgreen) |
-| [sentry-apps](charts/sentry-apps) | Sentry on premise | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 5.0.x](https://img.shields.io/badge/app%20version-5.0.x-brightgreen) |
+| [sentry-apps](charts/sentry-apps) | Sentry on premise | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 5.1.x](https://img.shields.io/badge/app%20version-5.1.x-brightgreen) |
 | [timed](charts/timed) | Chart for Timed application | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 1.1.x](https://img.shields.io/badge/app%20version-1.1.x-brightgreen) |
 
 ## Contributing

--- a/charts/sentry-apps/Chart.yaml
+++ b/charts/sentry-apps/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry-apps
 description: Sentry on premise
 type: application
-version: 0.2.2
-appVersion: 5.0.0
+version: 0.3.0
+appVersion: 5.1.1
 home: https://github.com/sentry-kubernetes/charts/tree/develop/sentry
 sources:
   - https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/sentry-apps

--- a/charts/sentry-apps/README.md
+++ b/charts/sentry-apps/README.md
@@ -1,6 +1,6 @@
 # sentry-apps
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.1.1](https://img.shields.io/badge/AppVersion-5.1.1-informational?style=flat-square)
 
 Sentry on premise
 


### PR DESCRIPTION
Upgrades Sentry to 20.8.1 which adds the snuba-transactions-consumer container.