### PR TITLE
:boom: (kasperleyn) deprecate chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ helm repo add adfinis https://charts.adfinis.com
 | [barman](charts/barman) | Chart for Barman PostgreSQL Backup and Recovery Manager | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 2.1.x](https://img.shields.io/badge/app%20version-2.1.x-brightgreen) |
 | [caasperli](charts/caasperli) | Deploy Caasperli to a Kubernetes Cluster | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: latest](https://img.shields.io/badge/app%20version-latest-brightgreen) |
 | [common](charts/common) | Common chartbuilding components and helpers, based on incubator/common | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 0.x](https://img.shields.io/badge/app%20version-0.x-brightgreen) |
-| [kasperleyn](charts/kasperleyn) | A Helm 2 chart to deploy Caasperli | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 1.0.x](https://img.shields.io/badge/app%20version-1.0.x-brightgreen) |
+| [kasperleyn](charts/kasperleyn) | A Helm 2 chart to deploy Caasperli | ![Version: 1.0.x](https://img.shields.io/badge/version-1.0.x-brightgreen) ![App version: 0.x](https://img.shields.io/badge/app%20version-0.x-brightgreen) |
 | [sentry-apps](charts/sentry-apps) | Sentry on premise | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 5.1.x](https://img.shields.io/badge/app%20version-5.1.x-brightgreen) |
 | [timed](charts/timed) | Chart for Timed application | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) ![App version: 1.1.x](https://img.shields.io/badge/app%20version-1.1.x-brightgreen) |
 

--- a/charts/kasperleyn/Chart.yaml
+++ b/charts/kasperleyn/Chart.yaml
@@ -1,10 +1,7 @@
 apiVersion: v1
 name: kasperleyn
+deprecated: true
 description: A Helm 2 chart to deploy Caasperli
-version: 0.3.5
-appVersion: "1.0"
+version: 1.0.0
+appVersion: "v0.1.2"
 home: https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape
-maintainers:
-  - name: adfinis-sygroup
-    email: support@adfinis.com
-    url: https://adfinis.com

--- a/charts/kasperleyn/README.md
+++ b/charts/kasperleyn/README.md
@@ -1,13 +1,12 @@
 # kasperleyn
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+> **:exclamation: This Helm Chart is deprecated!**
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: v0.1.2](https://img.shields.io/badge/AppVersion-v0.1.2-informational?style=flat-square)
 
 A Helm 2 chart to deploy Caasperli
 
 **Homepage:** <https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape>
-
-## Maintainers
-This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk_kwd=helm-charts).
 
 ## Values
 
@@ -17,7 +16,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"adfinissygroup/potz-holzoepfel-und-zipfelchape"` |  |
-| image.tag | string | `"latest"` |  |
+| image.tag | string | `"v0.1.2"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/kasperleyn/values.yaml
+++ b/charts/kasperleyn/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: adfinissygroup/potz-holzoepfel-und-zipfelchape
-  tag: latest
+  tag: v0.1.2
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
This will be the last Caasperli available for testing Helm v2 charts in isolation, thus I'm deprecating it as 1.0 (feature complete).

Once we merge this and get it through CD I'll get rid of the `charts/kasperleyn` folder as well.