### PR TITLE
chore(ci): replace deprecated add-path command

### DIFF
--- a/hack/ci/github/setup/pre-commit.sh
+++ b/hack/ci/github/setup/pre-commit.sh
@@ -10,7 +10,7 @@ mkdir -p $ADFINIS_CHARTS_TMP_BIN
 # Install deps
 source hack/sh/deps/helm-docs.sh
 source hack/sh/deps/gomplate.sh
-echo "::add-path::$ADFINIS_CHARTS_TMP_BIN"
+echo $ADFINIS_CHARTS_TMP_BIN >> $GITHUB_PATH
 
 # Set PY
-echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV

--- a/hack/ci/github/setup/release.sh
+++ b/hack/ci/github/setup/release.sh
@@ -9,4 +9,4 @@ mkdir -p $ADFINIS_CHARTS_TMP_BIN
 
 # Install deps
 source hack/sh/deps/gomplate.sh
-echo "::add-path::$ADFINIS_CHARTS_TMP_BIN"
+echo $ADFINIS_CHARTS_TMP_BIN >> $GITHUB_PATH


### PR DESCRIPTION
Stomps this warning and a similiar one about env vars:
![image](https://user-images.githubusercontent.com/116588/95311695-43c08200-088e-11eb-9ee4-5158e63717d5.png)

* [add-path docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path)
* [set env docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)