### PR TITLE
feat(misc-apps): add sentry-kubernetes app

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -30,6 +30,13 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | downscaler.repoURL | string | [repo](http://storage.googleapis.com/kubernetes-charts-incubator) | Repo URL |
 | downscaler.targetRevision | string | `"0.5.*"` | [kube-downscaler Helm chart](https://github.com/helm/charts/tree/master/incubator/kube-downscaler) version |
 | downscaler.values | object | [upstream values](https://github.com/helm/charts/blob/master/incubator/kube-downscaler/values.yaml) | Helm values |
+| sentryKubernetes | object | - | [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml) |
+| sentryKubernetes.chart | string | `"sentry-kubernetes"` | Chart |
+| sentryKubernetes.destination.namespace | string | `"infra-sentry-kubernetes"` | Namespace |
+| sentryKubernetes.enabled | bool | `false` | Enable sentry-kubernetes |
+| sentryKubernetes.repoURL | string | [repo](https://sentry-kubernetes.github.io/charts) | Repo URL |
+| sentryKubernetes.targetRevision | string | `"0.3.*"` | [sentry-kubernetes Helm chart](https://github.com/sentry-kubernetes/charts/tree/develop/sentry-kubernetes) |
+| sentryKubernetes.values | object | [upstream values](https://github.com/sentry-kubernetes/charts/blob/develop/sentry-kubernetes/values.yaml) | Helm values |
 | signalilo | object | - | [sigalilo](https://github.com/vshn/signalilo) ([example](./examples/signalilo.yaml)) |
 | signalilo.chart | string | `"signalilo"` | Chart |
 | signalilo.destination.namespace | string | `"infra-signalilo"` | Namespace |

--- a/charts/misc-apps/examples/sentry-kubernetes.yaml
+++ b/charts/misc-apps/examples/sentry-kubernetes.yaml
@@ -1,0 +1,8 @@
+_: &sentryDSN "https://secret@sentry.example.om/id"
+
+sentryKubernetes:
+  enabled: true
+  project: infra-sentry-kubernetes
+  values:
+    sentry:
+      dsn: *sentryDSN

--- a/charts/misc-apps/templates/NOTES.txt
+++ b/charts/misc-apps/templates/NOTES.txt
@@ -5,3 +5,6 @@ The following apps are available:
 {{ if .Values.signalilo.enabled }}
 * signalilo
 {{ end }}
+{{ if .Values.sentryKubernetes.enabled }}
+* sentry-kubernetes
+{{ end }}

--- a/charts/misc-apps/templates/sentry-kubernetes.yaml
+++ b/charts/misc-apps/templates/sentry-kubernetes.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.sentryKubernetes.enabled }}
+{{ template "argoconfig.application" (list . "misc-apps.sentryKubernetes") }}
+{{ end }}
+
+{{- define "misc-apps.sentryKubernetes" -}}{{- $app := unset .Values.sentryKubernetes "enabled" -}}{{- $name := default $app.destination.namespace $app.name -}}
+metadata:
+  name: {{ template "common.fullname" . }}-{{ $name }}
+spec:
+  {{- if $app.project }}
+  project: {{ $app.project | quote }}
+  {{- end }}
+  source:
+    repoURL: {{ $app.repoURL | quote }}
+    chart: {{ $app.chart | quote }}
+    targetRevision: {{ $app.targetRevision | quote }}
+    helm:
+      releaseName: {{ $name | quote }}
+      values: |-
+        nameOverride: {{ $name | quote }}
+        {{- $app.values | toYaml | nindent 8 }}
+  {{- if $app.destination }}
+  destination:
+    {{ $app.destination | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $app.syncPolicy }}
+  syncPolicy:
+    {{ $app.syncPolicy | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $app.ignoreDifferences }}
+  ignoreDifferences:
+    {{ $app.ignoreDifferences | toYaml | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -35,3 +35,22 @@ signalilo:
   # signalilo.values -- Helm values
   # @default -- [upstream values](https://github.com/appuio/charts/blob/master/signalilo/values.yaml)
   values: {}
+
+# sentryKubernetes -- [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml)
+# @default -- -
+sentryKubernetes:
+  # sentryKubernetes.enabled -- Enable sentry-kubernetes
+  enabled: false
+  destination:
+    # sentryKubernetes.destination.namespace -- Namespace
+    namespace: "infra-sentry-kubernetes"
+  # sentryKubernetes.repoURL -- Repo URL
+  # @default -- [repo](https://sentry-kubernetes.github.io/charts)
+  repoURL: "https://sentry-kubernetes.github.io/charts"
+  # sentryKubernetes.chart -- Chart
+  chart: "sentry-kubernetes"
+  # sentryKubernetes.targetRevision -- [sentry-kubernetes Helm chart](https://github.com/sentry-kubernetes/charts/tree/develop/sentry-kubernetes)
+  targetRevision: "0.3.*"
+  # sentryKubernetes.values -- Helm values
+  # @default -- [upstream values](https://github.com/sentry-kubernetes/charts/blob/develop/sentry-kubernetes/values.yaml)
+  values: {}


### PR DESCRIPTION
This prepares the misc-apps chart so we can use it to deploy [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) which will ship kubernetes events to sentry.