### PR TITLE
chore(infra-apps): bump cert-manager version to 1.1.*

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.1.2
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/infra-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | certManager.destination.namespace | string | `"infra-certManager"` | Namespace |
 | certManager.enabled | bool | `false` | Enable cert-manager |
 | certManager.repoURL | string | [repo](https://charts.jetstack.io) | Repo URL |
-| certManager.targetRevision | string | `"1.0.*"` | [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version |
+| certManager.targetRevision | string | `"1.1.*"` | [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version |
 | certManager.values | object | [upstream values](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml) | Helm values |
 | ingressNginx | object | [example](./examples/nginx-ingress.yaml) | [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) |
 | ingressNginx.chart | string | `"ingress-nginx"` | Chart |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -33,7 +33,7 @@ certManager:
   # certManager.chart -- Chart
   chart: "cert-manager"
   # certManager.targetRevision -- [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version
-  targetRevision: '1.0.*'
+  targetRevision: '1.1.*'
   # certManager.values -- Helm values
   # @default -- [upstream values](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml)
   values: {}


### PR DESCRIPTION
No special upgrade steps required according to the cert-manager documentation: https://cert-manager.io/docs/installation/upgrading/upgrading-1.0-1.1/