### PR TITLE
chore: configure cz-conventional-changelog in .czrc

### DIFF
--- a/.czrc
+++ b/.czrc
@@ -1,0 +1,3 @@
+{
+  "path": "cz-conventional-changelog"
+}


### PR DESCRIPTION
As a lot of us are already using it we might as well configure it as the default.