### PR TITLE
fix(misc-apps): add name into values

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.2.6
-appVersion: 0.2.6
+version: 0.2.7
+appVersion: 0.2.7
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.6](https://img.shields.io/badge/AppVersion-0.2.6-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.7](https://img.shields.io/badge/AppVersion-0.2.7-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -3,6 +3,7 @@
 downscaler:
   # downscaler.enabled -- Enable kube-downscaler
   enabled: false
+  name: downscaler
   destination:
     # downscaler.destination.namespace -- Namespace
     namespace: "infra-downscaler"
@@ -22,6 +23,7 @@ downscaler:
 signalilo:
   # signalilo.enabled -- Enable signalilo
   enabled: false
+  name: signalilo
   destination:
     # signalilo.destination.namespace -- Namespace
     namespace: "infra-signalilo"
@@ -41,6 +43,7 @@ signalilo:
 sentryKubernetes:
   # sentryKubernetes.enabled -- Enable sentry-kubernetes
   enabled: false
+  name: sentry-kubernetes
   destination:
     # sentryKubernetes.destination.namespace -- Namespace
     namespace: "infra-sentry-kubernetes"
@@ -60,6 +63,7 @@ sentryKubernetes:
 metallb:
   # metallb.enabled -- Enable metallb
   enabled: false
+  name: metallb
   destination:
     # metallb.destination.namespace -- Namespace
     namespace: "infra-metallb"


### PR DESCRIPTION
Had the strange issue, that fullnameOverride wasn't working as expected (got
`infra-infra-downscaler` as name).

This is my output without and with setting `name` inside `values.yaml`:

```
# with
…/charts/misc-apps helm template . --set downscaler.enabled=true --set fullnameOverride=infra | grep "name: "
  name: infra-downscaler

# without
…/charts/misc-apps helm template . --set downscaler.enabled=true --set fullnameOverride=infra | grep "name: "
  name: infra-infra-downscaler
```