### PR TITLE
fix(values.yaml): remove trailing slash from repoURL

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.2.7
-appVersion: 0.2.7
+version: 0.2.8
+appVersion: 0.2.8
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.7](https://img.shields.io/badge/AppVersion-0.2.7-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.8](https://img.shields.io/badge/AppVersion-0.2.8-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -27,7 +27,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | downscaler.chart | string | `"kube-downscaler"` | Chart |
 | downscaler.destination.namespace | string | `"infra-downscaler"` | Namespace |
 | downscaler.enabled | bool | `false` | Enable kube-downscaler |
-| downscaler.repoURL | string | [repo](https://charts.helm.sh/incubator/) | Repo URL |
+| downscaler.repoURL | string | [repo](https://charts.helm.sh/incubator) | Repo URL |
 | downscaler.targetRevision | string | `"0.5.*"` | [kube-downscaler Helm chart](https://github.com/helm/charts/tree/master/incubator/kube-downscaler) version |
 | downscaler.values | object | [upstream values](https://github.com/helm/charts/blob/master/incubator/kube-downscaler/values.yaml) | Helm values |
 | metallb | object | - | [metallb](https://github.com/metallb/metallb) ([example](./examples/metallb.yaml) |

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -8,8 +8,8 @@ downscaler:
     # downscaler.destination.namespace -- Namespace
     namespace: "infra-downscaler"
   # downscaler.repoURL -- Repo URL
-  # @default -- [repo](https://charts.helm.sh/incubator/)
-  repoURL: "https://charts.helm.sh/incubator/"
+  # @default -- [repo](https://charts.helm.sh/incubator)
+  repoURL: "https://charts.helm.sh/incubator"
   # downscaler.chart -- Chart
   chart: "kube-downscaler"
   # downscaler.targetRevision -- [kube-downscaler Helm chart](https://github.com/helm/charts/tree/master/incubator/kube-downscaler) version


### PR DESCRIPTION
Error in argocd if project sourceRepos do not have the trailing slash.