### PR TITLE
chore(ghcr.io): move image repo

### DIFF
--- a/charts/back8sup/Chart.yaml
+++ b/charts/back8sup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: back8sup
 description: Deploy back8sup to a Kubernetes Cluster
 type: application
-version: 0.2.1
-appVersion: v0.6.1
+version: 0.2.2
+appVersion: v0.7.1
 home: https://github.com/adfinis-sygroup/back8sup
 sources:
   - https://github.com/adfinis-sygroup/back8sup

--- a/charts/back8sup/Chart.yaml
+++ b/charts/back8sup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: back8sup
 description: Deploy back8sup to a Kubernetes Cluster
 type: application
-version: 0.2.2
+version: 0.3.0
 appVersion: v0.7.1
 home: https://github.com/adfinis-sygroup/back8sup
 sources:

--- a/charts/back8sup/README.md
+++ b/charts/back8sup/README.md
@@ -1,6 +1,6 @@
 # back8sup
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
 
 Deploy back8sup to a Kubernetes Cluster
 
@@ -40,7 +40,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | cronjob.successfulJobsHistoryLimit | string | `""` | specifies the successfulJobsHistoryLimit of the cronjob |
 | fullnameOverride | string | `""` | specifies the full name override to be used for helm |
 | image.pullPolicy | string | `"IfNotPresent"` | set the image pullPolicy |
-| image.repository | string | `"adfinissygroup/back8sup"` | set the image repository |
+| image.repository | string | `"ghcr.io/adfinis-sygroup/back8sup"` | set the image repository |
 | image.tag | string | `""` | set the tag of the image Specify a tag to override which version of timed to deploy. If no tag is specified the appVersion from Chart.yaml is used as tag. |
 | imagePullSecrets | list | `[]` | specifies the image pull secrets to be used |
 | nameOverride | string | `""` | specifies the name override to be used for helm |

--- a/charts/back8sup/README.md
+++ b/charts/back8sup/README.md
@@ -1,6 +1,6 @@
 # back8sup
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
 
 Deploy back8sup to a Kubernetes Cluster
 

--- a/charts/back8sup/values.yaml
+++ b/charts/back8sup/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   # image.repository -- set the image repository
-  repository: adfinissygroup/back8sup
+  repository: ghcr.io/adfinis-sygroup/back8sup
   # image.pullPolicy -- set the image pullPolicy
   pullPolicy: IfNotPresent
   # image.tag -- set the tag of the image


### PR DESCRIPTION
As `adfinissygroup/back8sup` moved to `ghcr.io/adfinis-sygroup/back8sup` this makes sure the charts uses the correct image