### PR TITLE
fix(chart-releaser): add dependency repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add adfinis https://charts.adfinis.com
+          helm repo add adfinis https://charts.adfinis.com && \
+          helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0


### PR DESCRIPTION
Adds the https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts repo to chart-releaser.

Can we put these inside a config file?