### PR TITLE
fix(caasperli): templates / configmapList, add name for ci

### DIFF
--- a/charts/caasperli/Chart.yaml
+++ b/charts/caasperli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caasperli
 description: Deploy Caasperli to a Kubernetes Cluster
 type: application
-version: 0.8.5
+version: 0.8.6
 appVersion: latest
 home: https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape
 sources:

--- a/charts/caasperli/README.md
+++ b/charts/caasperli/README.md
@@ -1,6 +1,6 @@
 # caasperli
 
-![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.8.6](https://img.shields.io/badge/Version-0.8.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Deploy Caasperli to a Kubernetes Cluster
 

--- a/charts/caasperli/templates/grafana/configmap-dashboard.yaml
+++ b/charts/caasperli/templates/grafana/configmap-dashboard.yaml
@@ -3,6 +3,8 @@
 {{- if $files }}
 apiVersion: v1
 kind: ConfigMapList
+metadata:
+  name: grafana-dashboards
 items:
 {{- range $path, $fileContents := $files }}
 {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}

--- a/charts/caasperli/templates/grafana/configmap-dashboard.yaml
+++ b/charts/caasperli/templates/grafana/configmap-dashboard.yaml
@@ -1,27 +1,23 @@
 {{- if .Values.grafana.enabled }}
 {{- $files := .Files.Glob "grafana/dashboards/*.json" }}
 {{- if $files }}
-apiVersion: v1
-kind: ConfigMapList
-metadata:
-  name: grafana-dashboards
-items:
 {{- range $path, $fileContents := $files }}
 {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: {{ printf "%s-%s" (include "caasperli.fullname" $) $dashboardName | trunc 63 | trimSuffix "-" }}
-    labels:
-      {{- include "caasperli.labels" $ | nindent 6 }}
-      {{- if $.Values.grafana.defaultLabel }}
-      grafana_dashboard: "1"
-      {{- end }}
-      {{- if $.Values.grafana.extraLabels }}
-      {{- $.Values.grafana.extraLabels | toYaml | nindent 6 }}
-      {{- end }}
-  data:
-    {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "caasperli.fullname" $) $dashboardName | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "caasperli.labels" $ | nindent 4 }}
+    {{- if $.Values.grafana.defaultLabel }}
+    grafana_dashboard: "1"
+    {{- end }}
+    {{- if $.Values.grafana.extraLabels }}
+    {{- $.Values.grafana.extraLabels | toYaml | nindent 4 }}
+    {{- end }}
+data:
+  {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
I'm not sure why this is happening. But adding a `name:` to the configMapList, solves the issue.

I removed everything beneith (keeping a very simple configmap with hard coded names) and it was still failing. This is when I realized the configMapList is in the eyes of helm also just a Object, but has no name defined (does not need it to work!).

We could migrate away from using `ConfigMapList` and just use good old `---\nobject...\n---\nobject`.

I'll let the decision to you @hairmare