### PR TITLE
chore(logging-apps): bump fluentd chart to 3.4.x

### DIFF
--- a/charts/logging-apps/Chart.yaml
+++ b/charts/logging-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: logging-apps
 description: Argo CD app-of-apps config for logging applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.2.1
-appVersion: 0.2.1
+version: 0.3.0
+appVersion: 0.3.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/logging-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/logging-apps/README.md
+++ b/charts/logging-apps/README.md
@@ -1,6 +1,6 @@
 # logging-apps
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for logging applications
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | fluentd.destination.namespace | string | `"infra-logging"` | Namespace |
 | fluentd.enabled | bool | `false` | Enable fluentd |
 | fluentd.repoURL | string | [repo](https://charts.bitnami.com/bitnami) | Repo URL |
-| fluentd.targetRevision | string | `"3.2.*"` | [fluentd Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/fluentd) version |
+| fluentd.targetRevision | string | `"3.4.*"` | [fluentd Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/fluentd) version |
 | fluentd.values | object | [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/fluentd/values.yaml) | Helm values |
 | lokiStack | object | - | [loki-stack](https://github.com/grafana/loki) ([example](./examples/loki-stack.yaml)) |
 | lokiStack.chart | string | `"loki-stack"` | Chart |

--- a/charts/logging-apps/values.yaml
+++ b/charts/logging-apps/values.yaml
@@ -53,7 +53,7 @@ fluentd:
   # fluentd.chart -- Chart
   chart: "fluentd"
   # fluentd.targetRevision -- [fluentd Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/fluentd) version
-  targetRevision: "3.2.*"
+  targetRevision: "3.4.*"
   # fluentd.values -- Helm values
   # @default -- [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/fluentd/values.yaml)
   values: {}


### PR DESCRIPTION
Changes:
* 3.3.0
  * add means to configurate liveness and readiness endpoints for forwarder and aggregator
* 3.4.0 
  * add missing features from stable/fluentd