### PR TITLE
chore(misc-apps): bump metallb chart version to 2.1.x

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.3.1
-appVersion: 0.3.1
+version: 0.4.0
+appVersion: 0.4.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | metallb.destination.namespace | string | `"infra-metallb"` | Namespace |
 | metallb.enabled | bool | `false` | Enable metallb |
 | metallb.repoURL | string | [repo](https://charts.bitnami.com/bitnami) | Repo URL |
-| metallb.targetRevision | string | `"2.0.*"` | [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb) |
+| metallb.targetRevision | string | `"2.1.*"` | [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb) |
 | metallb.values | object | [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/metallb/values.yaml) | Helm values |
 | sentryKubernetes | object | - | [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml) |
 | sentryKubernetes.chart | string | `"sentry-kubernetes"` | Chart |

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -73,7 +73,7 @@ metallb:
   # metallb.chart -- Chart
   chart: "metallb"
   # metallb.targetRevision -- [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb)
-  targetRevision: "2.0.*"
+  targetRevision: "2.1.*"
   # metallb.values -- Helm values
   # @default -- [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/metallb/values.yaml)
   values: {}


### PR DESCRIPTION
Changes:
* 2.1.0
  * Allow overrding secret key name in speaker secret when using an external speaker secret.