### PR TITLE
fix(quickfix/vault-monitoring): labeling issue on template of serviceMonitor

### DIFF
--- a/charts/vault-monitoring/Chart.yaml
+++ b/charts/vault-monitoring/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vault-monitoring
 description: monitor your vault server from within Kubernetes' prometheus
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-monitoring
 sources:
   - https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-monitoring

--- a/charts/vault-monitoring/README.md
+++ b/charts/vault-monitoring/README.md
@@ -1,6 +1,6 @@
 # vault-monitoring
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
 
 monitor your vault server from within Kubernetes' prometheus
 

--- a/charts/vault-monitoring/ci/default-values.yaml
+++ b/charts/vault-monitoring/ci/default-values.yaml
@@ -1,3 +1,5 @@
 vault:
   serviceMonitor:
     create: true
+    labels:
+      k8s.example.com/prometheus: kube-prometheus

--- a/charts/vault-monitoring/templates/servicemonitor.yaml
+++ b/charts/vault-monitoring/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "vaultMonitoring.labels" . | nindent 4 }}
 {{- if .Values.vault.serviceMonitor.labels }}
-    {{- toYaml .Values.serviceMonitor.labels | nindent 4}}
+    {{- toYaml .Values.vault.serviceMonitor.labels | nindent 4}}
 {{- end }}
 spec:
   selector:

--- a/charts/vault-monitoring/templates/servicemonitor.yaml
+++ b/charts/vault-monitoring/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "vaultMonitoring.labels" . | nindent 4 }}
 {{- if .Values.vault.serviceMonitor.labels }}
-    {{- toYaml .Values.vaultMonitoring.serviceMonitor.labels | nindent 4}}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4}}
 {{- end }}
 spec:
   selector:


### PR DESCRIPTION
This was a wrong doing in our initial Chart, never tested, as default values is "no labels"