### PR TITLE
chore(security-apps): bump falcosidekick chart version to 0.2.*

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.5.0
+appVersion: 0.5.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -49,7 +49,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | falcosidekick.destination.namespace | string | `"infra-falco"` | Namespace |
 | falcosidekick.enabled | bool | `false` | Enable falcosidekick |
 | falcosidekick.repoURL | string | [repo](https://falcosecurity.github.io/charts) | Repo URL |
-| falcosidekick.targetRevision | string | `"0.1.*"` | [falcosidekick Helm chart](https://github.com/falcosecurity/charts/tree/master/falcosidekick) version |
+| falcosidekick.targetRevision | string | `"0.2.*"` | [falcosidekick Helm chart](https://github.com/falcosecurity/charts/tree/master/falcosidekick) version |
 | falcosidekick.values | object | [upstream values](https://github.com/falcosecurity/charts/blob/master/falcosidekick/values.yaml) | Helm values |
 | gangway | object | - | [gangway](https://github.com/heptiolabs/gangway/) ([example](./examples/gangway.yaml)) |
 | gangway.chart | string | `"gangway"` | Chart |

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -93,7 +93,7 @@ falcosidekick:
   # falcosidekick.chart -- Chart
   chart: "falcosidekick"
   # falcosidekick.targetRevision -- [falcosidekick Helm chart](https://github.com/falcosecurity/charts/tree/master/falcosidekick) version
-  targetRevision: "0.1.*"
+  targetRevision: "0.2.*"
   # falcosidekick.values -- Helm values
   # @default -- [upstream values](https://github.com/falcosecurity/charts/blob/master/falcosidekick/values.yaml)
   values: {}


### PR DESCRIPTION
Changes:
## 0.2.2

### Major Changes

* Add `Kubeless` output
 
## 0.2.1

### Major Changes

* Add `PagerDuty` output

## 0.2.0

### Major Changes

* Add option to use an existing secret
* Add option to add extra environment variables
* Add `Stan` output

### Minor Changes

* Use the Existing secret resource and add all possible variables to there, and make it simpler to read and less error-prone in the deployment resource
