### PR TITLE
chore(updates): switch to latest tergetRevision

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.7.0
+appVersion: 0.7.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/infra-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -42,14 +42,14 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | ingressNginx.destination.namespace | string | `"infra-ingress"` | Namespace |
 | ingressNginx.enabled | bool | `false` | Configure nginx-ingress |
 | ingressNginx.repoURL | string | [repo](https://kubernetes.github.io/ingress-nginx) | Repo URL |
-| ingressNginx.targetRevision | string | `"3.20.*"` | [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) version |
+| ingressNginx.targetRevision | string | `"3.22.*"` | [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) version |
 | ingressNginx.values | object | [upstream values](https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/values.yaml) | Helm values |
 | kubePrometheusStack | object | [example](./examples/prometheus.yaml) | [prometheus-operator](https://github.com/coreos/prometheus-operator) |
 | kubePrometheusStack.chart | string | `"kube-prometheus-stack"` | Chart |
 | kubePrometheusStack.destination.namespace | string | `"infra-monitoring"` | Namespace |
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
-| kubePrometheusStack.targetRevision | string | `"13.3.*"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"13.4.*"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | rbacManager | object | [example](./examples/rbac-manager.yaml) | [rbac-manager](https://fairwindsops.github.io/rbac-manager/) |
 | rbacManager.chart | string | `"rbac-manager"` | Chart |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -53,7 +53,7 @@ ingressNginx:
   # ingressNginx.chart -- Chart
   chart: "ingress-nginx"
   # ingressNginx.targetRevision -- [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) version
-  targetRevision: '3.20.*'
+  targetRevision: '3.22.*'
   # ingressNginx.values -- Helm values
   # @default -- [upstream values](https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/values.yaml)
   values: {}
@@ -73,7 +73,7 @@ kubePrometheusStack:
   # kubePrometheusStack.chart -- Chart
   chart: "kube-prometheus-stack"
   # kubePrometheusStack.targetRevision -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: '13.3.*'
+  targetRevision: '13.4.*'
   # kubePrometheusStack.values -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
   values: {}

--- a/charts/logging-apps/Chart.yaml
+++ b/charts/logging-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: logging-apps
 description: Argo CD app-of-apps config for logging applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.5.0
+appVersion: 0.5.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/logging-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/logging-apps/README.md
+++ b/charts/logging-apps/README.md
@@ -1,6 +1,6 @@
 # logging-apps
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for logging applications
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | fluentd.destination.namespace | string | `"infra-logging"` | Namespace |
 | fluentd.enabled | bool | `false` | Enable fluentd |
 | fluentd.repoURL | string | [repo](https://charts.bitnami.com/bitnami) | Repo URL |
-| fluentd.targetRevision | string | `"3.4.*"` | [fluentd Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/fluentd) version |
+| fluentd.targetRevision | string | `"3.5.*"` | [fluentd Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/fluentd) version |
 | fluentd.values | object | [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/fluentd/values.yaml) | Helm values |
 | lokiStack | object | - | [loki-stack](https://github.com/grafana/loki) ([example](./examples/loki-stack.yaml)) |
 | lokiStack.chart | string | `"loki-stack"` | Chart |

--- a/charts/logging-apps/values.yaml
+++ b/charts/logging-apps/values.yaml
@@ -53,7 +53,7 @@ fluentd:
   # fluentd.chart -- Chart
   chart: "fluentd"
   # fluentd.targetRevision -- [fluentd Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/fluentd) version
-  targetRevision: "3.4.*"
+  targetRevision: "3.5.*"
   # fluentd.values -- Helm values
   # @default -- [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/fluentd/values.yaml)
   values: {}

--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.5.0
+appVersion: 0.5.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | metallb.destination.namespace | string | `"infra-metallb"` | Namespace |
 | metallb.enabled | bool | `false` | Enable metallb |
 | metallb.repoURL | string | [repo](https://charts.bitnami.com/bitnami) | Repo URL |
-| metallb.targetRevision | string | `"2.1.*"` | [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb) |
+| metallb.targetRevision | string | `"2.2.*"` | [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb) |
 | metallb.values | object | [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/metallb/values.yaml) | Helm values |
 | sentryKubernetes | object | - | [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml) |
 | sentryKubernetes.chart | string | `"sentry-kubernetes"` | Chart |

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -73,7 +73,7 @@ metallb:
   # metallb.chart -- Chart
   chart: "metallb"
   # metallb.targetRevision -- [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb)
-  targetRevision: "2.1.*"
+  targetRevision: "2.2.*"
   # metallb.values -- Helm values
   # @default -- [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/metallb/values.yaml)
   values: {}

--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.5.0
-appVersion: 0.5.0
+version: 0.6.0
+appVersion: 0.6.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | dex.destination.namespace | string | `"infra-dex"` | Namespace |
 | dex.enabled | bool | `false` | Enable dex |
 | dex.repoURL | string | [repo](https://charts.helm.sh/stable/) | Repo URL |
-| dex.targetRevision | string | `"2.10.*"` | [dex Helm chart](https://github.com/helm/charts/tree/master/stable/dex/) version |
+| dex.targetRevision | string | `"2.15.*"` | [dex Helm chart](https://github.com/helm/charts/tree/master/stable/dex/) version |
 | dex.values | object | [upstream values](https://github.com/helm/charts/tree/master/stable/dex/values.yaml) | Helm values |
 | falco | object | - | [falco](https://github.com/falcosecurity/falco/) ([example](./examples/falco.yaml)) |
 | falco.chart | string | `"falco"` | Chart |
@@ -42,7 +42,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | falcoExporter.destination.namespace | string | `"infra-falco"` | Namespace |
 | falcoExporter.enabled | bool | `false` | Enable falco-exporter |
 | falcoExporter.repoURL | string | [repo](https://falcosecurity.github.io/charts) | Repo URL |
-| falcoExporter.targetRevision | string | `"0.4.*"` | [falco Helm chart](https://github.com/falcosecurity/charts/tree/master/falco-exporter) version |
+| falcoExporter.targetRevision | string | `"0.5.*"` | [falco Helm chart](https://github.com/falcosecurity/charts/tree/master/falco-exporter) version |
 | falcoExporter.values | object | [upstream values](https://github.com/falcosecurity/charts/blob/master/falco-exporter/values.yaml) | Helm values |
 | falcosidekick | object | - | [falcosidekick](https://github.com/falcosecurity/falcosidekick/) ([example](./examples/falcosidekick.yaml)) |
 | falcosidekick.chart | string | `"falcosidekick"` | Chart |
@@ -70,7 +70,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | vault.destination.namespace | string | `"infra-vault"` | Namespace |
 | vault.enabled | bool | `false` | Enable vault |
 | vault.repoURL | string | [repo](https://helm.releases.hashicorp.com/) | Repo URL |
-| vault.targetRevision | string | `"0.8.*"` | [vault Helm chart](https://github.com/hashicorp/vault-helm) version |
+| vault.targetRevision | string | `"0.9.*"` | [vault Helm chart](https://github.com/hashicorp/vault-helm) version |
 | vault.values | object | [upstream values](https://github.com/hashicorp/vault-helm/tree/master/values.yaml) | Helm values |
 
 ## About this chart

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -13,7 +13,7 @@ dex:
   # dex.chart -- Chart
   chart: "dex"
   # dex.targetRevision -- [dex Helm chart](https://github.com/helm/charts/tree/master/stable/dex/) version
-  targetRevision: "2.10.*"
+  targetRevision: "2.15.*"
   # dex.values -- Helm values
   # @default -- [upstream values](https://github.com/helm/charts/tree/master/stable/dex/values.yaml)
   values: {}
@@ -53,7 +53,7 @@ vault:
   # vault.chart -- Chart
   chart: "vault"
   # vault.targetRevision -- [vault Helm chart](https://github.com/hashicorp/vault-helm) version
-  targetRevision: "0.8.*"
+  targetRevision: "0.9.*"
   # vault.values -- Helm values
   # @default -- [upstream values](https://github.com/hashicorp/vault-helm/tree/master/values.yaml)
   values: {}
@@ -113,7 +113,7 @@ falcoExporter:
   # falcoExporter.chart -- Chart
   chart: "falco-exporter"
   # falcoExporter.targetRevision -- [falco Helm chart](https://github.com/falcosecurity/charts/tree/master/falco-exporter) version
-  targetRevision: "0.4.*"
+  targetRevision: "0.5.*"
   # falcoExporter.values -- Helm values
   # @default -- [upstream values](https://github.com/falcosecurity/charts/blob/master/falco-exporter/values.yaml)
   values: {}

--- a/charts/storage-apps/Chart.yaml
+++ b/charts/storage-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: storage-apps
 description: Argo CD app-of-apps config for storage applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/storage-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/storage-apps/README.md
+++ b/charts/storage-apps/README.md
@@ -1,6 +1,6 @@
 # storage-apps
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for storage applications
 
@@ -28,14 +28,14 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | cephCsiCephfs.destination.namespace | string | `"infra-storage"` | Namespace |
 | cephCsiCephfs.enabled | bool | `false` | Enable ceph-csi-cephfs |
 | cephCsiCephfs.repoURL | string | [repo](https://ceph.github.io/csi-charts) | Repo URL |
-| cephCsiCephfs.targetRevision | string | `"1.3.*"` | [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version |
+| cephCsiCephfs.targetRevision | string | `"3.2.*"` | [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version |
 | cephCsiCephfs.values | object | [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/cephfs/ceph-csi-cephfs/values.yaml) | Helm values |
 | cephCsiRbd | object | - | [ceph-csi-rbd](https://github.com/ceph/ceph-csi/) |
 | cephCsiRbd.chart | string | `"ceph-csi-rbd"` | Chart |
 | cephCsiRbd.destination.namespace | string | `"infra-storage"` | Namespace |
 | cephCsiRbd.enabled | bool | `false` | Enable ceph-csi-rbd |
 | cephCsiRbd.repoURL | string | [repo](https://ceph.github.io/csi-charts) | Repo URL |
-| cephCsiRbd.targetRevision | string | `"1.3.*"` | [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version |
+| cephCsiRbd.targetRevision | string | `"3.2.*"` | [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version |
 | cephCsiRbd.values | object | [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/rbd/ceph-csi-rbd/values.yaml) | Helm values |
 | nfsClientProvisioner | object | - | [nfs-client-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) ([example](./examples/nfs-client-provisioner.yaml)) |
 | nfsClientProvisioner.chart | string | `"nfs-client-provisioner"` | Chart |

--- a/charts/storage-apps/values.yaml
+++ b/charts/storage-apps/values.yaml
@@ -33,7 +33,7 @@ cephCsiRbd:
   # cephCsiRbd.chart -- Chart
   chart: "ceph-csi-rbd"
   # cephCsiRbd.targetRevision -- [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version
-  targetRevision: "1.3.*"
+  targetRevision: "3.2.*"
   # cephCsiRbd.values -- Helm values
   # @default -- [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/rbd/ceph-csi-rbd/values.yaml)
   values: {}
@@ -53,7 +53,7 @@ cephCsiCephfs:
   # cephCsiCephfs.chart -- Chart
   chart: "ceph-csi-cephfs"
   # cephCsiCephfs.targetRevision -- [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version
-  targetRevision: "1.3.*"
+  targetRevision: "3.2.*"
   # cephCsiCephfs.values -- Helm values
   # @default -- [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/cephfs/ceph-csi-cephfs/values.yaml)
   values: {}


### PR DESCRIPTION
## infra

* ingress-nginx :arrow_up_small: `3.22.*`
* kube-prometheus-stack :arrow_up_small: `13.4.*`

## logging

* fluentd :arrow_up_small: `3.5.*`

## misc
* metallb :arrow_up_small: `2.2.*`

## security

* dex :arrow_up_small: `2.15.*`
* vault :arrow_up_small: `0.9.*`
* falco-exporter :arrow_up_small: `0.5.*`

## storage

* ceph-csi-rbd :arrow_up_small: `3.2.*`
* ceph-csi-cephfs :arrow_up_small: `3.2.*`