### PR TITLE
Feature/improving barman chart pv handling

### DIFF
--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: barman
 type: application
 description: Chart for Barman PostgreSQL Backup and Recovery Manager
-version: 0.0.13
+version: 0.0.14
 appVersion: "2.10"
 keywords:
   - barman

--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: barman
 type: application
 description: Chart for Barman PostgreSQL Backup and Recovery Manager
-version: 0.0.14
+version: 0.1.0
 appVersion: "2.10"
 keywords:
   - barman

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -62,7 +62,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | prometheus.serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
 | prometheus.serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |
 | rbac.create | bool | `false` | Whether to create RBAC or not |
-| resources | object | `{}` | Resource limits and requests |
+| resources | object | `{"limits":{"ram":"256MiB"},"requests":{"cpu":"100m","ram":"128MiB"}}` | Resource limits and requests |
 
 ## About this chart
 

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -1,6 +1,6 @@
 # barman
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10](https://img.shields.io/badge/AppVersion-2.10-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10](https://img.shields.io/badge/AppVersion-2.10-informational?style=flat-square)
 
 Chart for Barman PostgreSQL Backup and Recovery Manager
 

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -62,7 +62,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | prometheus.serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
 | prometheus.serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |
 | rbac.create | bool | `false` | Whether to create RBAC or not |
-| resources | object | `{"limits":{"ram":"256MiB"},"requests":{"cpu":"100m","ram":"128MiB"}}` | Resource limits and requests |
+| resources | object | `{"limits":{"memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource limits and requests |
 
 ## About this chart
 

--- a/charts/barman/templates/NOTES.txt
+++ b/charts/barman/templates/NOTES.txt
@@ -6,9 +6,13 @@ See: http://docs.pgbarman.org/release/2.10/#setup-of-a-new-server-in-barman
 
 Initial backup:
 
+  * Get the pod name and export it
+
+    export BARMAN_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "barman.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+
   * Obtain a bash shell on the running Barman pod.
 
-    kubectl --namespace {{ .Release.Namespace }} exec -it {{ template "barman.fullname" . }}-0 /bin/bash
+    kubectl --namespace {{ .Release.Namespace }} exec -it ${BARMAN_POD_NAME} /bin/bash
 
   * Switch to the Barman user.
 
@@ -28,9 +32,13 @@ Initial backup:
 
 Restore:
 
+  * Get the pod name and export it
+
+    export BARMAN_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "barman.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+
   * Obtain a bash shell on the running Barman pod.
 
-    kubectl --namespace {{ .Release.Namespace }} exec -it {{ template "barman.fullname" . }}-0 /bin/bash
+    kubectl --namespace {{ .Release.Namespace }} exec -it ${BARMAN_POD_NAME} /bin/bash
 
   * Switch to the Barman user.
 

--- a/charts/barman/templates/deployment.yaml
+++ b/charts/barman/templates/deployment.yaml
@@ -1,19 +1,14 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "barman.fullname" . }}
   labels:
     {{- include "barman.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ template "barman.fullname" . }}
   replicas: 1
   selector:
     matchLabels:
       {{- include "barman.selectorLabels" . | nindent 6 }}
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      partition: 0
   template:
     metadata:
       labels:
@@ -89,32 +84,3 @@ spec:
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
     {{- end }}
-  {{- if or .Values.persistence.data.enabled .Values.persistence.recover.enabled }}
-  volumeClaimTemplates:
-    {{- if .Values.persistence.data.enabled }}
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-          - {{ .Values.persistence.data.accessMode | quote }}
-      {{- if .Values.persistence.data.storageClass }}
-        storageClassName: {{ .Values.persistence.data.storageClass | quote }}
-      {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.persistence.data.size | quote }}
-    {{- end }}
-    {{- if .Values.persistence.recover.enabled }}
-    - metadata:
-        name: recover
-      spec:
-        accessModes:
-          - {{ .Values.persistence.recover.accessMode | quote }}
-      {{- if .Values.persistence.recover.storageClass }}
-        storageClassName: {{ .Values.persistence.recover.storageClass | quote }}
-      {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.persistence.recover.size | quote }}
-    {{- end }}
-  {{- end }}

--- a/charts/barman/templates/deployment.yaml
+++ b/charts/barman/templates/deployment.yaml
@@ -59,13 +59,19 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        {{- if not .Values.persistence.data.enabled }}
         - name: data
+        {{- if not .Values.persistence.data.enabled }}
           emptyDir: {}
+        {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "barman.fullname" . }}-data
         {{- end }}
-        {{- if not .Values.persistence.recover.enabled }}
         - name: recover
+        {{- if not .Values.persistence.recover.enabled }}
           emptyDir: {}
+        {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "barman.fullname" . }}-recover
         {{- end }}
         - name: barman-backups-config
           configMap:

--- a/charts/barman/templates/pvc.yaml
+++ b/charts/barman/templates/pvc.yaml
@@ -5,8 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     {{- include "barman.labels" . | nindent 4 }}
-  name: data
-  namespace: infra-barman
+  name: {{ include "barman.fullname" . }}-data
 spec:
   accessModes:
   - {{ .Values.persistence.data.accessMode | quote }}
@@ -24,8 +23,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     {{- include "barman.labels" . | nindent 4 }}
-  name: recover
-  namespace: infra-barman
+  name: {{ include "barman.fullname" . }}-recover
 spec:
   accessModes:
   - {{ .Values.persistence.recover.accessMode | quote }}

--- a/charts/barman/templates/pvc.yaml
+++ b/charts/barman/templates/pvc.yaml
@@ -1,4 +1,3 @@
-{{- if or .Values.persistence.data.enabled .Values.persistence.recover.enabled }}
 {{- if .Values.persistence.data.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -33,5 +32,4 @@ spec:
   {{- if .Values.persistence.recover.storageClass }}
   storageClassName: {{ .Values.persistence.recover.storageClass | quote }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/barman/templates/pvc.yaml
+++ b/charts/barman/templates/pvc.yaml
@@ -1,0 +1,39 @@
+{{- if or .Values.persistence.data.enabled .Values.persistence.recover.enabled }}
+{{- if .Values.persistence.data.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    {{- include "barman.labels" . | nindent 4 }}
+  name: data
+  namespace: infra-barman
+spec:
+  accessModes:
+  - {{ .Values.persistence.data.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.persistence.recover.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    {{- include "barman.labels" . | nindent 4 }}
+  name: recover
+  namespace: infra-barman
+spec:
+  accessModes:
+  - {{ .Values.persistence.recover.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.recover.size | quote }}
+  {{- if .Values.persistence.recover.storageClass }}
+  storageClassName: {{ .Values.persistence.recover.storageClass | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/barman/values.yaml
+++ b/charts/barman/values.yaml
@@ -7,7 +7,12 @@ image:
   pullPolicy: Always
 
 # resources -- Resource limits and requests
-resources: {}
+resources:
+  requests:
+    cpu: 100m
+    ram: 128MiB
+  limits:
+    ram: 256MiB
 
 persistence:
   data:

--- a/charts/barman/values.yaml
+++ b/charts/barman/values.yaml
@@ -10,9 +10,9 @@ image:
 resources:
   requests:
     cpu: 100m
-    ram: 128MiB
+    memory: 128Mi
   limits:
-    ram: 256MiB
+    memory: 256Mi
 
 persistence:
   data:


### PR DESCRIPTION
updated barman chart:
* replaced statefulset with a deployment
* pvc creation covered by helm and not by statefulset-controller

further notes:
* online resizing of pvc is still not possible on azure (https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/273)
* argo deployment in aks int test pending