### PR TITLE
feat(dummyDeployment): addition

### DIFF
--- a/charts/csi-secret-provider-class/Chart.lock
+++ b/charts/csi-secret-provider-class/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.adfinis.com
-  version: 0.0.5
-digest: sha256:9ee68395c06e42a72b7e849e1df7b3be6c658ade9aa4911d195d8e380981f7fb
-generated: "2020-12-03T16:06:53.437610587+01:00"
+  version: 0.0.6
+digest: sha256:4edcfcd9255737c0241e307f3995fb95bd439158e4913f5a1dd625fd386299a7
+generated: "2021-02-18T09:05:21.861467522+01:00"

--- a/charts/csi-secret-provider-class/Chart.yaml
+++ b/charts/csi-secret-provider-class/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: csi-secret-provider-class
 description: A Helm chart to create a SecretProviderClass resource
 type: application
-version: 0.1.1
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/csi-secret-provider-class
 sources:
   - https://github.com/adfinis-sygroup/helm-charts
@@ -14,4 +14,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://charts.adfinis.com
-    version: 0.0.5
+    version: 0.0.6

--- a/charts/csi-secret-provider-class/README.md
+++ b/charts/csi-secret-provider-class/README.md
@@ -25,7 +25,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 |-----|------|---------|-------------|
 | dummyDeployment.affinity | object | {} | sets affinity rules on the  deployment |
 | dummyDeployment.enabled | bool | false | enable the dummy deployment |
-| dummyDeployment.image.pullPolicy | string | `"ifNotPresent"` | When to pull the container image @defualt -- ifNotPresent |
+| dummyDeployment.image.pullPolicy | string | ifNotPresent | When to pull the container image |
 | dummyDeployment.image.repository | string | k8s.gcr.io/pause | Container image to deploy |
 | dummyDeployment.image.tag | string | 3.4.1 | sets the image tag to use |
 | dummyDeployment.nodeSelector | object | {} | sets a nodeSelector on the  deployment |

--- a/charts/csi-secret-provider-class/README.md
+++ b/charts/csi-secret-provider-class/README.md
@@ -1,6 +1,6 @@
 # csi-secret-provider-class
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart to create a SecretProviderClass resource
 
@@ -17,12 +17,21 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.adfinis.com | common | 0.0.5 |
+| https://charts.adfinis.com | common | 0.0.6 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| dummyDeployment.affinity | object | {} | sets affinity rules on the  deployment |
+| dummyDeployment.enabled | bool | false | enable the dummy deployment |
+| dummyDeployment.image.pullPolicy | string | `"ifNotPresent"` | When to pull the container image @defualt -- ifNotPresent |
+| dummyDeployment.image.repository | string | k8s.gcr.io/pause | Container image to deploy |
+| dummyDeployment.image.tag | string | 3.4.1 | sets the image tag to use |
+| dummyDeployment.nodeSelector | object | {} | sets a nodeSelector on the  deployment |
+| dummyDeployment.podAnnotations | object | {} | sets Pod annotations on the deployment |
+| dummyDeployment.resources | object | {} | sets resources like limits and requests on the  deployment |
+| dummyDeployment.tolerations | list | [] | sets tolerations on the  deployment |
 | parameters | object | `{}` | parameters for provider |
 | parametersTpl | string | raw values from `parameters` | template to generate parameters |
 | provider | string | `nil` | specify secret provider |

--- a/charts/csi-secret-provider-class/README.md
+++ b/charts/csi-secret-provider-class/README.md
@@ -25,7 +25,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 |-----|------|---------|-------------|
 | dummyDeployment.affinity | object | {} | sets affinity rules on the  deployment |
 | dummyDeployment.enabled | bool | false | enable the dummy deployment |
-| dummyDeployment.image.pullPolicy | string | ifNotPresent | When to pull the container image |
+| dummyDeployment.image.pullPolicy | string | IfNotPresent | When to pull the container image |
 | dummyDeployment.image.repository | string | k8s.gcr.io/pause | Container image to deploy |
 | dummyDeployment.image.tag | string | 3.4.1 | sets the image tag to use |
 | dummyDeployment.nodeSelector | object | {} | sets a nodeSelector on the  deployment |

--- a/charts/csi-secret-provider-class/README.md
+++ b/charts/csi-secret-provider-class/README.md
@@ -23,15 +23,15 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dummyDeployment.affinity | object | {} | sets affinity rules on the  deployment |
-| dummyDeployment.enabled | bool | false | enable the dummy deployment |
-| dummyDeployment.image.pullPolicy | string | IfNotPresent | When to pull the container image |
-| dummyDeployment.image.repository | string | k8s.gcr.io/pause | Container image to deploy |
-| dummyDeployment.image.tag | string | 3.4.1 | sets the image tag to use |
-| dummyDeployment.nodeSelector | object | {} | sets a nodeSelector on the  deployment |
-| dummyDeployment.podAnnotations | object | {} | sets Pod annotations on the deployment |
-| dummyDeployment.resources | object | {} | sets resources like limits and requests on the  deployment |
-| dummyDeployment.tolerations | list | [] | sets tolerations on the  deployment |
+| dummyDeployment.affinity | object | `{}` | sets affinity rules on the  deployment |
+| dummyDeployment.enabled | bool | `false` | enable the dummy deployment |
+| dummyDeployment.image.pullPolicy | string | `"IfNotPresent"` | When to pull the container image |
+| dummyDeployment.image.repository | string | `"k8s.gcr.io/pause"` | Container image to deploy |
+| dummyDeployment.image.tag | string | `"3.4.1"` | sets the image tag to use |
+| dummyDeployment.nodeSelector | object | `{}` | sets a nodeSelector on the  deployment |
+| dummyDeployment.podAnnotations | object | `{}` | sets Pod annotations on the deployment |
+| dummyDeployment.resources | object | `{}` | sets resources like limits and requests on the  deployment |
+| dummyDeployment.tolerations | list | `[]` | sets tolerations on the  deployment |
 | parameters | object | `{}` | parameters for provider |
 | parametersTpl | string | raw values from `parameters` | template to generate parameters |
 | provider | string | `nil` | specify secret provider |

--- a/charts/csi-secret-provider-class/ci/default-values.yaml
+++ b/charts/csi-secret-provider-class/ci/default-values.yaml
@@ -3,3 +3,5 @@ parameters:
   foo: bar
 secretObjects:
   - secretName: test
+dummyDeployment:
+  enabled: true

--- a/charts/csi-secret-provider-class/templates/_helpers.tpl
+++ b/charts/csi-secret-provider-class/templates/_helpers.tpl
@@ -1,41 +1,10 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "csi-secret-provider-class.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "csi-secret-provider-class.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "csi-secret-provider-class.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
 
 {{/*
 Common labels
 */}}
 {{- define "csi-secret-provider-class.labels" -}}
-helm.sh/chart: {{ include "csi-secret-provider-class.chart" . }}
+helm.sh/chart: {{ include "common.chartref" . }}
 {{ include "csi-secret-provider-class.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -47,17 +16,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "csi-secret-provider-class.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "csi-secret-provider-class.name" . }}
+app.kubernetes.io/name: {{ include "common.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "csi-secret-provider-class.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "csi-secret-provider-class.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/charts/csi-secret-provider-class/templates/_helpers.tpl
+++ b/charts/csi-secret-provider-class/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "csi-secret-provider-class.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "csi-secret-provider-class.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "csi-secret-provider-class.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "csi-secret-provider-class.labels" -}}
+helm.sh/chart: {{ include "csi-secret-provider-class.chart" . }}
+{{ include "csi-secret-provider-class.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "csi-secret-provider-class.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "csi-secret-provider-class.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "csi-secret-provider-class.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "csi-secret-provider-class.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/csi-secret-provider-class/templates/deployment.yaml
+++ b/charts/csi-secret-provider-class/templates/deployment.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.dummyDeployment.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{ template "common.metadata" $ }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "csi-secret-provider-class.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.dummyDeployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "csi-secret-provider-class.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: dummy
+          image: {{ .Values.dummyDeployment.image.repository }}:{{ .Values.dummyDeployment.image.tag }}
+          imagePullPolicy: {{ .Values.dummyDeployment.image.pullPolicy }}
+          {{- with .Values.dummyDeployment.resources }}
+          resources:
+            {{- toYaml .Values.dummyDeployment.resources | nindent 12 }}
+          {{- end }}
+      {{- with .Values.dummyDeployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dummyDeployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dummyDeployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: csi-secret-store-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "common.fullname" . }}
+{{- end }}

--- a/charts/csi-secret-provider-class/templates/deployment.yaml
+++ b/charts/csi-secret-provider-class/templates/deployment.yaml
@@ -1,8 +1,7 @@
 {{- if .Values.dummyDeployment.enabled }}
 apiVersion: apps/v1
 kind: Deployment
-metadata:
-  {{ template "common.metadata" $ }}
+{{ template "common.metadata" . }}
 spec:
   selector:
     matchLabels:

--- a/charts/csi-secret-provider-class/templates/deployment.yaml
+++ b/charts/csi-secret-provider-class/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           imagePullPolicy: {{ .Values.dummyDeployment.image.pullPolicy }}
           {{- with .Values.dummyDeployment.resources }}
           resources:
-            {{- toYaml .Values.dummyDeployment.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.dummyDeployment.nodeSelector }}
       nodeSelector:

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -15,7 +15,7 @@ secretObjects: []
 # @default -- raw values from `secretObjects`
 secretObjectsTpl: "{{ .Values.secretObjects | toYaml }}"
 
-# Creates a dummy deployment which uses the csiVolue. This is a hack, in case your Deployment in case your App/Chart isn't enabled to define extraVolumes
+# Creates a dummy Deployment which uses the csiVolume. This is a hack, in case your Chart doesn't support defining extraVolumes
 dummyDeployment:
   # dummyDeployment.enabled -- enable the dummy deployment
   # @default -- false

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -14,3 +14,34 @@ secretObjects: []
 # secretObjectsTpl -- template to generate secretObjects
 # @default -- raw values from `secretObjects`
 secretObjectsTpl: "{{ .Values.secretObjects | toYaml }}"
+
+# Creates a dummy deployment which uses the csiVolue. This is a hack, in case your Deployment in case your App/Chart isn't enabled to define extraVolumes
+dummyDeployment:
+  # dummyDeployment.enabled -- enable the dummy deployment
+  # @default -- false
+  enabled: false
+  image:
+    # dummyDeployment.image.repository -- Container image to deploy
+    # @default -- k8s.gcr.io/pause
+    repository: k8s.gcr.io/pause
+    # dummyDeployment.image.tag -- sets the image tag to use
+    # @default -- 3.4.1
+    tag: 3.4.1
+    # dummyDeployment.image.pullPolicy -- When to pull the container image
+    # @defualt -- ifNotPresent
+    pullPolicy: ifNotPresent
+  # dummyDeployment.podAnnotations -- sets Pod annotations on the deployment
+  # @default -- {}
+  podAnnotations: {}
+  # dummyDeployment.nodeSelector -- sets a nodeSelector on the  deployment
+  # @default -- {}
+  nodeSelector: {}
+  # dummyDeployment.affinity -- sets affinity rules on the  deployment
+  # @default -- {}
+  affinity: {}
+  # dummyDeployment.tolerations -- sets tolerations on the  deployment
+  # @default -- []
+  tolerations: []
+  # dummyDeployment.resources -- sets resources like limits and requests on the  deployment
+  # @default -- {}
+  resources: {}

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -30,8 +30,7 @@ dummyDeployment:
     # @default -- 3.4.1
     tag: 3.4.1
     # dummyDeployment.image.pullPolicy -- When to pull the container image
-    # @default -- ifNotPresent
-    pullPolicy: ifNotPresent
+    pullPolicy: IfNotPresent
   # dummyDeployment.podAnnotations -- sets Pod annotations on the deployment
   # @default -- {}
   podAnnotations: {}

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -20,14 +20,11 @@ secretObjectsTpl: "{{ .Values.secretObjects | toYaml }}"
 # Always try to use extraVolume Bindings inside your already existing Chart or application to make csi-secret-store manage the secret. And if there aren't any possibilities to mount additional volumes in your chart, try and create a pull-request upstream adding the feature to the chart.
 dummyDeployment:
   # dummyDeployment.enabled -- enable the dummy deployment
-  # @default -- false
   enabled: false
   image:
     # dummyDeployment.image.repository -- Container image to deploy
-    # @default -- k8s.gcr.io/pause
     repository: k8s.gcr.io/pause
     # dummyDeployment.image.tag -- sets the image tag to use
-    # @default -- 3.4.1
     tag: 3.4.1
     # dummyDeployment.image.pullPolicy -- When to pull the container image
     pullPolicy: IfNotPresent

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -28,7 +28,7 @@ dummyDeployment:
     # @default -- 3.4.1
     tag: 3.4.1
     # dummyDeployment.image.pullPolicy -- When to pull the container image
-    # @defualt -- ifNotPresent
+    # @default -- ifNotPresent
     pullPolicy: ifNotPresent
   # dummyDeployment.podAnnotations -- sets Pod annotations on the deployment
   # @default -- {}

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -16,7 +16,7 @@ secretObjects: []
 secretObjectsTpl: "{{ .Values.secretObjects | toYaml }}"
 
 # Creates a dummy Deployment which uses the csiVolume. This is a hack, in case your Chart doesn't support defining extraVolumes
-# DISCLAIMER: DO NOT USE THIS unless as last resort. 
+# DISCLAIMER: DO NOT USE THIS unless as last resort.
 # Always try to use extraVolume Bindings inside your already existing Chart or application to make csi-secret-store manage the secret. And if there aren't any possibilities to mount additional volumes in your chart, try and create a pull-request upstream adding the feature to the chart.
 dummyDeployment:
   # dummyDeployment.enabled -- enable the dummy deployment

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -16,6 +16,8 @@ secretObjects: []
 secretObjectsTpl: "{{ .Values.secretObjects | toYaml }}"
 
 # Creates a dummy Deployment which uses the csiVolume. This is a hack, in case your Chart doesn't support defining extraVolumes
+# DISCLAIMER: DO NOT USE THIS unless as last resort. 
+# Always try to use extraVolume Bindings inside your already existing Chart or application to make csi-secret-store manage the secret. And if there aren't any possibilities to mount additional volumes in your chart, try and create a pull-request upstream adding the feature to the chart.
 dummyDeployment:
   # dummyDeployment.enabled -- enable the dummy deployment
   # @default -- false

--- a/charts/csi-secret-provider-class/values.yaml
+++ b/charts/csi-secret-provider-class/values.yaml
@@ -29,17 +29,12 @@ dummyDeployment:
     # dummyDeployment.image.pullPolicy -- When to pull the container image
     pullPolicy: IfNotPresent
   # dummyDeployment.podAnnotations -- sets Pod annotations on the deployment
-  # @default -- {}
   podAnnotations: {}
   # dummyDeployment.nodeSelector -- sets a nodeSelector on the  deployment
-  # @default -- {}
   nodeSelector: {}
   # dummyDeployment.affinity -- sets affinity rules on the  deployment
-  # @default -- {}
   affinity: {}
   # dummyDeployment.tolerations -- sets tolerations on the  deployment
-  # @default -- []
   tolerations: []
   # dummyDeployment.resources -- sets resources like limits and requests on the  deployment
-  # @default -- {}
   resources: {}


### PR DESCRIPTION
Adds a dummyDeployment Option to be able to make the vault-secret-store provider create the secret if extraVolumes can't be used inside the Chart/App.