### PR TITLE
fix(barman): templates/_helpers.tpl fullNameOverride addition + release name contains

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 # Add specific owners to specific charts where ownership extends above group
 /charts/argoconfig                  @adfinis-sygroup/helm-charts @hairmare
 /charts/back8sup                    @adfinis-sygroup/helm-charts @eyenx @tongpu
-/charts/barman                      @adfinis-sygroup/helm-charts @michaelimfeld
+/charts/barman                      @adfinis-sygroup/helm-charts @michaelimfeld @sinicis
 /charts/common                      @adfinis-sygroup/helm-charts @hairmare
 /charts/csi-secret-provider-class   @adfinis-sygroup/helm-charts @hairmare
 /charts/timed                       @adfinis-sygroup/helm-charts @michaelimfeld @aziiee

--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: barman
 type: application
 description: Chart for Barman PostgreSQL Backup and Recovery Manager
-version: 0.1.0
+version: 0.1.1
 appVersion: "2.10"
 keywords:
   - barman

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -1,6 +1,6 @@
 # barman
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10](https://img.shields.io/badge/AppVersion-2.10-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10](https://img.shields.io/badge/AppVersion-2.10-informational?style=flat-square)
 
 Chart for Barman PostgreSQL Backup and Recovery Manager
 

--- a/charts/barman/templates/_helpers.tpl
+++ b/charts/barman/templates/_helpers.tpl
@@ -11,9 +11,17 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "barman.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Common labels


### PR DESCRIPTION
Fixes the nameOverride by not creating 

`barman-barman-config` if `$name` is contained in the `$releaseName`