### PR TITLE
chore(vault-csi-provider): update provider to 0.0.7 and dep to 0.0.20

### DIFF
--- a/charts/vault-csi-provider/Chart.lock
+++ b/charts/vault-csi-provider/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: secrets-store-csi-driver
   repository: https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
-  version: 0.0.19
-digest: sha256:f559171c58aa588ef0f5018d0baa3028ed8f5b7819403ac8c5df2ec755063137
-generated: "2021-02-10T17:14:11.868508342+01:00"
+  version: 0.0.20
+digest: sha256:a0f92925ebcda24f42b648288fb4a40582f513cf8a96dabc2c3689bfa549fbff
+generated: "2021-03-19T07:38:09.168342477+01:00"

--- a/charts/vault-csi-provider/Chart.yaml
+++ b/charts/vault-csi-provider/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: vault-csi-provider
 home: https://github.com/adfinis-sygroup/helm-charts/blob/master/charts/vault-csi-provider/README.md
 description: A helm chart to install the vault secrets-store-csi-driver
-version: 0.2.2
-appVersion: 0.0.6
+version: 0.2.3
+appVersion: 0.0.7
 dependencies:
   - name: secrets-store-csi-driver
-    version: 0.0.19
+    version: 0.0.20
     repository: "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts"
     condition: secretsStoreCsiDriver.enabled
 maintainers:

--- a/charts/vault-csi-provider/README.md
+++ b/charts/vault-csi-provider/README.md
@@ -21,7 +21,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 |-----|------|---------|-------------|
 | csiProviderPath | string | `"/etc/kubernetes/secrets-store-csi-providers"` | set the path where the secrets-store-csi-provider gets installed on the node |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"hashicorp/secrets-store-csi-driver-provider-vault","tag":"0.0.7"}` | specifies the image to use for the secrets-store-csi-driver |
-| resources | object | `{"limits":{"cpu":"50m","memory":"100Mi"},"requests":{"cpu":"50m","memory":"100Mi"}}` | Set the limits and requests on vault csi-driver-provider pod resources |
+| resources | object | `{}` | Set the limits and requests on vault csi-driver-provider pod resources |
 | secretsStoreCsiDriver.enabled | bool | `true` | specifies wether or not the secrets-store-csi-driver dependency gets installed |
 
 ## About this chart

--- a/charts/vault-csi-provider/README.md
+++ b/charts/vault-csi-provider/README.md
@@ -1,6 +1,6 @@
 # vault-csi-provider
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![AppVersion: 0.0.6](https://img.shields.io/badge/AppVersion-0.0.6-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: 0.0.7](https://img.shields.io/badge/AppVersion-0.0.7-informational?style=flat-square)
 
 A helm chart to install the vault secrets-store-csi-driver
 
@@ -13,15 +13,15 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts | secrets-store-csi-driver | 0.0.19 |
+| https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts | secrets-store-csi-driver | 0.0.20 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | csiProviderPath | string | `"/etc/kubernetes/secrets-store-csi-providers"` | set the path where the secrets-store-csi-provider gets installed on the node |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"hashicorp/secrets-store-csi-driver-provider-vault","tag":"0.0.6"}` | specifies the image to use for the secrets-store-csi-driver |
-| resources | object | `{}` | Set the limits and requests on vault csi-driver-provider pod resources |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"hashicorp/secrets-store-csi-driver-provider-vault","tag":"0.0.7"}` | specifies the image to use for the secrets-store-csi-driver |
+| resources | object | `{"limits":{"cpu":"50m","memory":"100Mi"},"requests":{"cpu":"50m","memory":"100Mi"}}` | Set the limits and requests on vault csi-driver-provider pod resources |
 | secretsStoreCsiDriver.enabled | bool | `true` | specifies wether or not the secrets-store-csi-driver dependency gets installed |
 
 ## About this chart

--- a/charts/vault-csi-provider/templates/daemonset.yaml
+++ b/charts/vault-csi-provider/templates/daemonset.yaml
@@ -31,4 +31,4 @@ spec:
           hostPath:
             path: {{ .Values.csiProviderPath }}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/charts/vault-csi-provider/templates/daemonset.yaml
+++ b/charts/vault-csi-provider/templates/daemonset.yaml
@@ -30,3 +30,5 @@ spec:
         - name: providervol
           hostPath:
             path: {{ .Values.csiProviderPath }}
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/charts/vault-csi-provider/values.yaml
+++ b/charts/vault-csi-provider/values.yaml
@@ -10,13 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 # resources -- Set the limits and requests on vault csi-driver-provider pod resources
-resources:
-  requests:
-    cpu: 50m
-    memory: 100Mi
-  limits:
-    cpu: 50m
-    memory: 100Mi
+resources: {}
 
 # csiProviderPath -- set the path where the secrets-store-csi-provider gets installed on the node
 csiProviderPath: "/etc/kubernetes/secrets-store-csi-providers"

--- a/charts/vault-csi-provider/values.yaml
+++ b/charts/vault-csi-provider/values.yaml
@@ -6,11 +6,17 @@
 # image -- specifies the image to use for the secrets-store-csi-driver
 image:
   repository: hashicorp/secrets-store-csi-driver-provider-vault
-  tag: 0.0.6
+  tag: 0.0.7
   pullPolicy: IfNotPresent
 
 # resources -- Set the limits and requests on vault csi-driver-provider pod resources
-resources: {}
+resources:
+  requests:
+    cpu: 50m
+    memory: 100Mi
+  limits:
+    cpu: 50m
+    memory: 100Mi
 
 # csiProviderPath -- set the path where the secrets-store-csi-provider gets installed on the node
 csiProviderPath: "/etc/kubernetes/secrets-store-csi-providers"


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

* Updates our vault-csi-provider to use image tag 0.0.7 and adds default resources, as in the deployment example [changelog](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/releases/tag/0.0.7)
* Updates the dependency of secrets-store-csi-driver to 0.0.20 [changelog](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.0.20)


<!-- Describe the changes your PR introduces here. -->

# Issues

n/a
<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->