### PR TITLE
feat(security-apps): secrets-store-csi-driver addition)

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.10.1
-appVersion: 0.10.1
+version: 0.11.0
+appVersion: 0.11.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -65,6 +65,13 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | gatekeeper.repoURL | string | [repo](https://open-policy-agent.github.io/gatekeeper/charts) | Repo URL |
 | gatekeeper.targetRevision | string | `"3.2.2"` | [gatekeeper Helm chart](https://github.com/open-policy-agent/gatekeeper/tree/master/charts/gatekeeper) version |
 | gatekeeper.values | object | [upstream values](https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/values.yaml) | Helm values |
+| secretsStoreCsiDriver | object | - | [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) ([examplpe](./examples/secrets-store-csi-driver.yaml)) |
+| secretsStoreCsiDriver.chart | string | `"secrets-store-csi-driver"` | Chart |
+| secretsStoreCsiDriver.destination.namespace | string | `"infra-secrets-store-csi"` | Namespace |
+| secretsStoreCsiDriver.enabled | bool | `false` | Enable secrets-store-csi-driver |
+| secretsStoreCsiDriver.repoURL | string | [repo](https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts) | Repo URL |
+| secretsStoreCsiDriver.targetRevision | string | `"0.0.*"` | [vault-csi-provider Helm chart](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver) version |
+| secretsStoreCsiDriver.values | object | [upstream values](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver/values.yaml) | Helm values |
 | vault | object | - | [vault](https://github.com/hashicorp/vault/) ([example](./examples/vault.yaml)) |
 | vault.chart | string | `"vault"` | Chart |
 | vault.destination.namespace | string | `"infra-vault"` | Namespace |
@@ -74,18 +81,21 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | vault.values | object | [upstream values](https://github.com/hashicorp/vault-helm/tree/master/values.yaml) | Helm values |
 | vaultAuth | object | - | [vault-auth](https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-auth) ([example](./examples/vault-auth.yaml)) |
 | vaultAuth.chart | string | `"vault-auth"` | Chart |
+| vaultAuth.destination.namespace | string | `"infra-vault"` | Namespace |
 | vaultAuth.enabled | bool | `false` | Enable vault-auth |
 | vaultAuth.repoURL | string | [repo](https://charts.adfinis.com/) | Repo URL |
 | vaultAuth.targetRevision | string | `"0.1.*"` | [vault-auth Helm chart](https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-auth) version |
 | vaultAuth.values | object | [upstream values](https://github.com/adfinis-sygroup/helm-charts/blob/master/charts/vault-auth/values.yaml) | Helm values |
 | vaultCsiProvider | object | - | [vault-csi-provider](https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-csi-provider) ([example](./examples/vault-csi-provider.yaml)) |
 | vaultCsiProvider.chart | string | `"vault-csi-provider"` | Chart |
+| vaultCsiProvider.destination.namespace | string | `"infra-vault"` | Namespace |
 | vaultCsiProvider.enabled | bool | `false` | Enable vault-csi-provider |
 | vaultCsiProvider.repoURL | string | [repo](https://charts.adfinis.com/) | Repo URL |
 | vaultCsiProvider.targetRevision | string | `"0.2.*"` | [vault-csi-provider Helm chart](https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-csi-provider) version |
 | vaultCsiProvider.values | object | [upstream values](https://github.com/adfinis-sygroup/helm-charts/blob/master/charts/vault-csi-provider/values.yaml) | Helm values |
 | vaultMonitoring | object | - | [vault-monitoring](https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-monitoring) ([example](./examples/vault-monitoring.yaml)) |
 | vaultMonitoring.chart | string | `"vault-monitoring"` | Chart |
+| vaultMonitoring.destination.namespace | string | `"infra-vault"` | Namespace |
 | vaultMonitoring.enabled | bool | `false` | Enable vault-monitoring |
 | vaultMonitoring.repoURL | string | [repo](https://charts.adfinis.com/) | Repo URL |
 | vaultMonitoring.targetRevision | string | `"0.1.*"` | [vault-monitoring Helm chart](https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/vault-monitoring) version |

--- a/charts/security-apps/ci/default-values.yaml
+++ b/charts/security-apps/ci/default-values.yaml
@@ -37,3 +37,7 @@ vaultCsiProvider:
 vaultMonitoring:
   enabled: true
   values: {}
+
+secretsStoreCsiDriver:
+  enabled: true
+  values: {}

--- a/charts/security-apps/examples/secrets-store-csi-driver.yaml
+++ b/charts/security-apps/examples/secrets-store-csi-driver.yaml
@@ -1,0 +1,5 @@
+secretsStoreCsiDriver:
+  enabled: true
+  project: infra-secrets-store-csi
+  values:
+    enableSecretRotation: true

--- a/charts/security-apps/templates/secrets-store-csi-driver.yaml
+++ b/charts/security-apps/templates/secrets-store-csi-driver.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.secretsStoreCsiDriver.enabled }}
+{{ template "argoconfig.application" (list . "security-apps.secretsStoreCsiDriver") }}
+{{ end }}
+
+{{- define "security-apps.secretsStoreCsiDriver" -}}{{- $app := unset .Values.secretsStoreCsiDriver "enabled" -}}{{- $name := default $app.destination.namespace $app.name -}}
+metadata:
+  name: {{ template "common.fullname" . }}-{{ $name }}
+spec:
+  {{- if $app.project }}
+  project: {{ $app.project | quote }}
+  {{- end }}
+  source:
+    repoURL: {{ $app.repoURL | quote }}
+    chart: {{ $app.chart | quote }}
+    targetRevision: {{ $app.targetRevision | quote }}
+    helm:
+      releaseName: {{ $name | quote }}
+      values: |-
+        nameOverride: {{ $name | quote }}
+        {{- $app.values | toYaml | nindent 8 }}
+  {{- if $app.destination }}
+  destination:
+    {{ $app.destination | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $app.syncPolicy }}
+  syncPolicy:
+    {{ $app.syncPolicy | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $app.ignoreDifferences }}
+  ignoreDifferences:
+    {{ $app.ignoreDifferences | toYaml | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -145,7 +145,7 @@ vaultAuth:
   enabled: false
   name: vault-auth
   destination:
-    # vault-auth.destination.namespace -- Namespace
+    # vaultAuth.destination.namespace -- Namespace
     namespace: "infra-vault"
   # vaultAuth.repoURL -- Repo URL
   # @default -- [repo](https://charts.adfinis.com/)
@@ -165,7 +165,7 @@ vaultCsiProvider:
   enabled: false
   name: vault-csi-provider
   destination:
-    # vault-csi-provider.destination.namespace -- Namespace
+    # vaultCsiProvider.destination.namespace -- Namespace
     namespace: "infra-vault"
   # vaultCsiProvider.repoURL -- Repo URL
   # @default -- [repo](https://charts.adfinis.com/)
@@ -185,7 +185,7 @@ vaultMonitoring:
   enabled: false
   name: vault-monitoring
   destination:
-    # vault-monitoring.destination.namespace -- Namespace
+    # vaultMonitoring.destination.namespace -- Namespace
     namespace: "infra-vault"
   # vaultMonitoring.repoURL -- Repo URL
   # @default -- [repo](https://charts.adfinis.com/)
@@ -196,4 +196,24 @@ vaultMonitoring:
   targetRevision: "0.1.*"
   # vaultMonitoring.values -- Helm values
   # @default -- [upstream values](https://github.com/adfinis-sygroup/helm-charts/blob/master/charts/vault-monitoring/values.yaml)
+  values: {}
+
+# secretsStoreCsiDriver -- [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) ([examplpe](./examples/secrets-store-csi-driver.yaml))
+# @default -- -
+secretsStoreCsiDriver:
+  # secretsStoreCsiDriver.enabled -- Enable secrets-store-csi-driver
+  enabled: false
+  name: secrets-store-csi-driver
+  destination:
+    # secretsStoreCsiDriver.destination.namespace -- Namespace
+    namespace: "infra-secrets-store-csi"
+  # secretsStoreCsiDriver.repoURL -- Repo URL
+  # @default -- [repo](https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts)
+  repoURL: "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts"
+  # secretsStoreCsiDriver.chart -- Chart
+  chart: "secrets-store-csi-driver"
+    # secretsStoreCsiDriver.targetRevision -- [vault-csi-provider Helm chart](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver) version
+  targetRevision: "0.0.*"
+  # secretsStoreCsiDriver.values -- Helm values
+  # @default -- [upstream values](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Adds the secrets-store-csi-driver application to the security-apps.

First step needed for deprecating `vaultAuth` and `vaultCsiProvider` in favor of just using `vault` official helm chart.

as the secrets-store-csi-driver doesn't get installed with the official helm chart of hashicorp, we need to add this as an additional application.

<!-- Describe the changes your PR introduces here. -->

# Issues


n/a
<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->