### PR TITLE
fix(timed): use named ports instead of repeating number

### DIFF
--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 description: Chart for Timed application
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: v1.2.0
 keywords:
   - timed

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -1,6 +1,6 @@
 # timed
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 Chart for Timed application
 

--- a/charts/timed/templates/deployment-backend.yaml
+++ b/charts/timed/templates/deployment-backend.yaml
@@ -36,7 +36,8 @@ spec:
               subPath: workreport
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.backend.service.internalPort }}
+            - name: http
+              containerPort: {{ .Values.backend.service.internalPort }}
           {{- if .Values.backend.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.backend.livenessProbe.initialDelaySeconds }}
@@ -46,7 +47,7 @@ spec:
             failureThreshold: {{ .Values.backend.livenessProbe.failureThreshold }}
             httpGet:
               path: /admin/
-              port: {{ .Values.backend.service.internalPort }}
+              port: http
               httpHeaders:
                 - name: Host
                   value: {{ mustFirst .Values.ingress.hosts | default "localhost" }}
@@ -60,7 +61,7 @@ spec:
             failureThreshold: {{ .Values.backend.readinessProbe.failureThreshold }}
             httpGet:
               path: /admin/
-              port: {{ .Values.backend.service.internalPort }}
+              port: http
               httpHeaders:
                 - name: Host
                   value: {{ mustFirst .Values.ingress.hosts | default "localhost" }}

--- a/charts/timed/templates/deployment-frontend.yaml
+++ b/charts/timed/templates/deployment-frontend.yaml
@@ -24,7 +24,8 @@ spec:
             - configMapRef:
                 name: {{ include "timed.fullname" . }}-frontend
           ports:
-            - containerPort: {{ .Values.frontend.service.internalPort }}
+            - name: http
+              containerPort: {{ .Values.frontend.service.internalPort }}
           {{- if .Values.frontend.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds }}
@@ -34,7 +35,7 @@ spec:
             failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold }}
             httpGet:
               path: /index.html
-              port: {{ .Values.frontend.service.internalPort }}
+              port: http
           {{- end }}
           {{- if .Values.frontend.readinessProbe.enabled }}
           readinessProbe:
@@ -45,7 +46,7 @@ spec:
             failureThreshold: {{ .Values.frontend.readinessProbe.failureThreshold }}
             httpGet:
               path: /index.html
-              port: {{ .Values.frontend.service.internalPort }}
+              port: http
           {{- end }}
           resources:
 {{ toYaml .Values.frontend.resources | indent 12 }}

--- a/charts/timed/templates/prometheus/podmonitor.yaml
+++ b/charts/timed/templates/prometheus/podmonitor.yaml
@@ -15,7 +15,7 @@ spec:
       {{- include "timed.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: backend
   podMetricsEndpoints:
-    - port: {{ .Values.backend.service.internalPort }}
+    - port: http
       {{- if .Values.prometheus.podMonitor.interval }}
       interval: {{ .Values.prometheus.podMonitor.interval }}
       {{- end }}

--- a/charts/timed/templates/service-backend.yaml
+++ b/charts/timed/templates/service-backend.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.backend.service.type }}
   ports:
     - port: {{ .Values.backend.service.externalPort }}
-      targetPort: {{ .Values.backend.service.internalPort }}
+      targetPort: http
       protocol: TCP
       name: {{ .Values.backend.service.name }}
   selector:

--- a/charts/timed/templates/service-frontend.yaml
+++ b/charts/timed/templates/service-frontend.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.frontend.service.type }}
   ports:
     - port: {{ .Values.frontend.service.externalPort }}
-      targetPort: {{ .Values.frontend.service.internalPort }}
+      targetPort: http
       protocol: TCP
       name: {{ .Values.frontend.service.name }}
   selector:


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Fixes this error:
> PodMonitor.monitoring.coreos.com "timed-backend" is invalid: spec.podMetricsEndpoints.port: Invalid value: "integer": spec.podMetricsEndpoints.port in body must be of type string: "integer"

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
