### PR TITLE
fix(timed): use podIP from status for allowed hosts

### DIFF
--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 description: Chart for Timed application
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: v1.2.0
 keywords:
   - timed

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -1,6 +1,6 @@
 # timed
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 Chart for Timed application
 

--- a/charts/timed/templates/configmap-backend.yaml
+++ b/charts/timed/templates/configmap-backend.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/component: backend
 data:
   EMAIL_URL: {{ .Values.backend.settings.emailUrl | quote }}
-  DJANGO_ALLOWED_HOSTS: {{ join "," .Values.ingress.hosts | default "localhost" }}
   DJANGO_HOST_DOMAIN: {{ mustFirst .Values.ingress.hosts | default "localhost" | quote }}
   DJANGO_HOST_PROTOCOL: http{{- if .Values.ingress.tls }}s{{- end }}
   DJANGO_DEFAULT_FROM_EMAIL: {{ .Values.backend.settings.emailFrom | quote }}

--- a/charts/timed/templates/cronjob-backend.yaml
+++ b/charts/timed/templates/cronjob-backend.yaml
@@ -1,3 +1,4 @@
+{{- $ingressHosts := .Values.ingress.hosts }}
 {{- range $key, $val := .Values.backend.cronjobs }}
 ---
 apiVersion: batch/v1beta1
@@ -25,6 +26,12 @@ spec:
                     secretKeyRef:
                       name: {{ include "timed.postgresql.fullname" $ }}
                       key: postgresql-password
+                - name: THIS_POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: DJANGO_ALLOWED_HOSTS
+                  value: '{{ join "," $ingressHosts | default "localhost" }},$(THIS_POD_IP)'
               envFrom:
                 - secretRef:
                     name: {{ include "timed.fullname" $ }}-backend

--- a/charts/timed/templates/deployment-backend.yaml
+++ b/charts/timed/templates/deployment-backend.yaml
@@ -25,6 +25,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "timed.postgresql.fullname" . }}
                   key: postgresql-password
+            - name: THIS_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: DJANGO_ALLOWED_HOSTS
+              value: '{{ join "," .Values.ingress.hosts | default "localhost" }},$(THIS_POD_IP)'
           envFrom:
             - secretRef:
                 name: {{ include "timed.fullname" . }}-backend

--- a/charts/timed/templates/job-dbmigrate.yaml
+++ b/charts/timed/templates/job-dbmigrate.yaml
@@ -28,6 +28,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "timed.postgresql.fullname" . }}
                   key: postgresql-password
+            - name: THIS_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: DJANGO_ALLOWED_HOSTS
+              value: '{{ join "," .Values.ingress.hosts | default "localhost" }},$(THIS_POD_IP)'
           envFrom:
             - secretRef:
                 name: {{ include "timed.fullname" . }}-backend


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
We need to set ALLOWED_HOSTS to the pods IP to allow it to get scraped by Prometheus and @sbor23 found [this gem](https://github.com/korfuri/django-prometheus/issues/81#issuecomment-456210855).

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
