### PR TITLE
docs(infra-apps): remove deprecated beta.kubernetes.io/os label from kured example

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.20.0
-appVersion: 0.20.0
+version: 0.20.1
+appVersion: 0.20.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/infra-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0](https://img.shields.io/badge/AppVersion-0.20.0-informational?style=flat-square)
+![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.1](https://img.shields.io/badge/AppVersion-0.20.1-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 

--- a/charts/infra-apps/examples/kured.yaml
+++ b/charts/infra-apps/examples/kured.yaml
@@ -5,7 +5,7 @@ kured:
   values:
     nodeSelector:
       # kured only works on/for Linux nodes
-      beta.kubernetes.io/os: Linux
+      kubernetes.io/os: Linux
     service:
       # create service for the metrics endpoint
       create: true


### PR DESCRIPTION
# Description

The `beta.kubernetes.io/os` label has been deprecated since v1.14 so we should replace it with the correct `kubernetes.io/os` label in the kured configuration example.

# Issues

n/a

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released