### PR TITLE
feat(caasperli): add support for networking.k8s.io/v1 Ingress

### DIFF
--- a/charts/caasperli/Chart.yaml
+++ b/charts/caasperli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caasperli
 description: Deploy Caasperli to a Kubernetes Cluster
 type: application
-version: 0.8.7
+version: 0.9.0
 appVersion: latest
 home: https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape
 sources:

--- a/charts/caasperli/README.md
+++ b/charts/caasperli/README.md
@@ -1,6 +1,6 @@
 # caasperli
 
-![Version: 0.8.7](https://img.shields.io/badge/Version-0.8.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Deploy Caasperli to a Kubernetes Cluster
 
@@ -23,7 +23,6 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| deploymentAnnotations | object | `{}` | Annotations to add to Deployment. |
 | fullnameOverride | string | `""` |  |
 | grafana.defaultLabel | bool | `true` | Add a default `grafana_dashboard: 1` label |
 | grafana.enabled | bool | `false` | Enable Grafana Dashboards |
@@ -33,8 +32,9 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | image.tag | string | `""` | Overrides the image tag whose default is the chart version. |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Annotations to add to the ingress resource |
+| ingress.className | string | `""` | Which Ingress class to configure for the ingress resource |
 | ingress.enabled | bool | `false` | Enable ingress |
-| ingress.hosts | list | `[{"host":"chart-example.local","paths":[]}]` | List of hosts to expose via ingress |
+| ingress.hosts | list | `[]` | List of hosts to expose via ingress |
 | ingress.tls | list | `[]` | TLS configuration for ingress |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/caasperli/templates/NOTES.txt
+++ b/charts/caasperli/templates/NOTES.txt
@@ -9,7 +9,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/caasperli/templates/_helpers.tpl
+++ b/charts/caasperli/templates/_helpers.tpl
@@ -1,4 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/caasperli/templates/deployment.yaml
+++ b/charts/caasperli/templates/deployment.yaml
@@ -4,23 +4,19 @@ metadata:
   name: {{ include "caasperli.fullname" . }}
   labels:
     {{- include "caasperli.labels" . | nindent 4 }}
-  {{- with .Values.deploymentAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
-{{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-{{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "caasperli.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+      {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       labels:
         {{- include "caasperli.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/caasperli/templates/hpa.yaml
+++ b/charts/caasperli/templates/hpa.yaml
@@ -13,16 +13,16 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-  {{- end }}
-  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-  {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/caasperli/templates/ingress.yaml
+++ b/charts/caasperli/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "caasperli.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,6 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -32,10 +42,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/caasperli/templates/tests/test-connection.yaml
+++ b/charts/caasperli/templates/tests/test-connection.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "caasperli.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
   containers:
     - name: wget

--- a/charts/caasperli/values.yaml
+++ b/charts/caasperli/values.yaml
@@ -26,9 +26,6 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# deploymentAnnotations -- Annotations to add to Deployment.
-deploymentAnnotations: {}
-
 # podAnnotations -- Annotations to add to Pod.
 podAnnotations: {}
 
@@ -54,14 +51,18 @@ service:
 ingress:
   # ingress.enabled -- Enable ingress
   enabled: false
+  # ingress.className -- Which Ingress class to configure for the ingress resource
+  className: ""
   # ingress.annotations -- Annotations to add to the ingress resource
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # ingress.hosts -- List of hosts to expose via ingress
-  hosts:
-    - host: chart-example.local
-      paths: []
+  hosts: []
+  #  - host: chart-example.local
+  #    paths:
+  #      - path: /
+  #        pathType: Prefix
   # ingress.tls -- TLS configuration for ingress
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
# Description

This change introduces support for `networking.k8s.io/v1` Ingress configuration and some other changes to align with helm create from Helm v3.6.

BREAKING CHANGE: Ingress configuration in `values.yaml` has changed and `deploymentAnnotations` has been removed from `values.yaml`.

This PR supersedes #259.

# Issues

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released