### PR TITLE
feat(tracing-apps): bump jaeger-operator to 2.21

### DIFF
--- a/charts/tracing-apps/Chart.yaml
+++ b/charts/tracing-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: tracing-apps
 description: Argo CD app-of-apps config for tracing applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/tracing-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/tracing-apps/README.md
+++ b/charts/tracing-apps/README.md
@@ -1,6 +1,6 @@
 # tracing-apps
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for tracing applications
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | jaegerOperator.destination.namespace | string | `"infra-jaeger"` | Namespace |
 | jaegerOperator.enabled | bool | `false` | Enable jaeger-operator |
 | jaegerOperator.repoURL | string | [repo](https://jaegertracing.github.io/helm-charts) | Repo URL |
-| jaegerOperator.targetRevision | string | `"2.18.*"` | [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/master/charts/jaeger-operator) |
+| jaegerOperator.targetRevision | string | `"2.21.*"` | [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/master/charts/jaeger-operator) |
 | jaegerOperator.values | object | [upstream values](https://github.com/jaegertracing/helm-charts/blob/master/charts/jaeger-operator/values.yaml) | Helm values |
 
 ## About this chart

--- a/charts/tracing-apps/values.yaml
+++ b/charts/tracing-apps/values.yaml
@@ -13,7 +13,7 @@ jaegerOperator:
   # jaegerOperator.chart -- Chart
   chart: "jaeger-operator"
   # jaegerOperator.targetRevision -- [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/master/charts/jaeger-operator)
-  targetRevision: "2.18.*"
+  targetRevision: "2.21.*"
   # jaegerOperator.values -- Helm values
   # @default -- [upstream values](https://github.com/jaegertracing/helm-charts/blob/master/charts/jaeger-operator/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Contains heaps of changes from upstream (but none should be bc breaking)

## Jaeger chart
### 2.22.*

* specify env variables for deployment via extraEnv value

### 2.21.*

* update jaeger-operator to 1.22.1

### 2.20.*

* fix NodePort services

### 2.19.*

* Fix CRD schema
* update jaeger-operator to 1.21.2

## Jaeger Operator

### 1.22.2 

* Add preserve unknown fields annotation to FreeForm and Options fields 
* Migrate remaining flags and some env vars to 1.22 
* Fix override storage and ingress values when upgrade to 1.22 
* Add agent dnsPolicy option 

### 1.22.1 
* Allow configure custom certificates to collector 
* Add support for NodePort in Jaeger Query Service 

### 1.22.0 
* Add ability to indicate PriorityClass for collector and query 
* simplest example file should be as simplest 
* Add ability to indicate PriorityClass for agent 
* Migrate jaeger.tags in existing CRs 

### 1.21.3 

* Remove support for the experimental OpenTelemetry-based Jaeger 
* Fix way we force es secret reconcile 
* added the codeql.yml 
* Fix service port naming convention 
* Add volumes and volume-mounts for spark dependencies 
* Create missing CA config maps on deployment controller 
* set non root group 
* Kafka 2.4 not supported by RH AMQ operator 1.6 
* Trigger deployments reconciliation when jaeger instance is created 
* Copy common spec to avoid touching persisted CR spec 
* Try to resolve container.name from the injected agent args 
* Fix typo in CONTRIBUTING.md 

### 1.21.2 

* Fixes jaeger version 

### 1.21.1 

* Update UI documentation link if is present 

### 1.21.0 

* Regenerate self-provisioned ES TLS cert when it's outdated 
* Enable tolerations support in elasticsearch config 
* Update github.com/miekg/dns to v1.1.35 
* Add serviceType for the collector service 
* Add env var JAEGER_DISABLED 
* Fix secret creation when using self provisioned elasticsearch instances 
* Convert storage type to typed string 
* Use New Admin Port Flag 
* Update instances status using client.Status
* Remove gRPC host-port from being added to the CR 
* Sync OTEL config volume/mount and args 
* Publish container - dockerx should not use tag BUILD_IMAGE 
* Speed up buildx process 
* Fix the dependencies 
* Add agent hostNetwork option 
* Skip detectClusterRoles for Kubernetes 
* Elasticsearch: add SYS_CHROOT capability 
* Allow overriding the vertx example app image and config values 
* Simplify OTEL related environment variables 
* Add CQLSH_PORT environment variable 
* Expose elasticsearch container ports 
* Adding samples for ingress hosts and annotations 
* Don't set kafka batch options when using otel collector 

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
