### PR TITLE
Configure GitHub container registry as default repository for Caasperli

### DIFF
--- a/charts/caasperli/Chart.yaml
+++ b/charts/caasperli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caasperli
 description: Deploy Caasperli to a Kubernetes Cluster
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: latest
 home: https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape
 sources:

--- a/charts/caasperli/README.md
+++ b/charts/caasperli/README.md
@@ -1,6 +1,6 @@
 # caasperli
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Deploy Caasperli to a Kubernetes Cluster
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | grafana.enabled | bool | `false` | Enable Grafana Dashboards |
 | grafana.extraLabels | object | `{}` | Labels to add to all Grafana integration resources |
 | image.pullPolicy | string | `"Always"` | When to pull the container image |
-| image.repository | string | `"adfinissygroup/potz-holzoepfel-und-zipfelchape"` | Container image to deploy |
+| image.repository | string | `"ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape"` | Container image to deploy |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart version. |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Annotations to add to the ingress resource |

--- a/charts/caasperli/values.yaml
+++ b/charts/caasperli/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   # image.repository -- Container image to deploy
-  repository: adfinissygroup/potz-holzoepfel-und-zipfelchape
+  repository: ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape
   # image.pullPolicy -- When to pull the container image
   pullPolicy: Always
   # image.tag -- Overrides the image tag whose default is the chart version.


### PR DESCRIPTION
# Description

Change the default repository for the Caasperli image to GitHub container registry

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released