### PR TITLE
chore(infra-apps): update cert-manager to v1.4

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.34.0
-appVersion: 0.34.0
+version: 0.35.0
+appVersion: 0.35.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/infra-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.34.0](https://img.shields.io/badge/AppVersion-0.34.0-informational?style=flat-square)
+![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.35.0](https://img.shields.io/badge/AppVersion-0.35.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -42,7 +42,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | certManager.destination.namespace | string | `"infra-certmanager"` | Namespace |
 | certManager.enabled | bool | `false` | Enable cert-manager |
 | certManager.repoURL | string | [repo](https://charts.jetstack.io) | Repo URL |
-| certManager.targetRevision | string | `"1.3.*"` | [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version |
+| certManager.targetRevision | string | `"1.4.*"` | [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version |
 | certManager.values | object | [upstream values](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml) | Helm values |
 | certManagerIssuers.chart | string | `"cert-manager-issuers"` | Chart |
 | certManagerIssuers.destination.namespace | string | `"infra-certmanager"` | Namespace |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -51,7 +51,7 @@ certManager:
   # certManager.chart -- Chart
   chart: "cert-manager"
   # certManager.targetRevision -- [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version
-  targetRevision: '1.3.*'
+  targetRevision: '1.4.*'
   # certManager.values -- Helm values
   # @default -- [upstream values](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Update cert-manager to v1.4

None of the urgent upgrade notes are relevant for us:
* The CA issuer now attempts to store the root CA instead of the issuing CA into the ca.crt field for issued certificates; this is a change of behavior. All of the information which was previously available is still available: the intermediate should appear as part of the chain in tls.crt.
* RunAsNonRoot is now enabled by default in the securityContext values. If you're using custom containers with the chart that run as root, you will need to set this back to false.

# Issues

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
