### PR TITLE
feat(security-apps): upgrade dex Helm chart to 0.5.0

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.22.0
-appVersion: 0.22.0
+version: 0.23.0
+appVersion: 0.23.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.0](https://img.shields.io/badge/AppVersion-0.22.0-informational?style=flat-square)
+![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.0](https://img.shields.io/badge/AppVersion-0.23.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | dex.destination.namespace | string | `"infra-dex"` | Namespace |
 | dex.enabled | bool | `false` | Enable dex |
 | dex.repoURL | string | [repo](https://charts.dexidp.io) | Repo URL |
-| dex.targetRevision | string | `"0.3.*"` | [dex Helm chart](https://github.com/dexidp/helm-charts/tree/master/charts/dex/) version |
+| dex.targetRevision | string | `"0.5.*"` | [dex Helm chart](https://github.com/dexidp/helm-charts/tree/master/charts/dex/) version |
 | dex.values | object | [upstream values](https://github.com/dexidp/helm-charts/tree/master/charts/dex/values.yaml) | Helm values |
 | falco | object | - | [falco](https://github.com/falcosecurity/falco/) ([example](./examples/falco.yaml)) |
 | falco.chart | string | `"falco"` | Chart |

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -13,7 +13,7 @@ dex:
   # dex.chart -- Chart
   chart: "dex"
   # dex.targetRevision -- [dex Helm chart](https://github.com/dexidp/helm-charts/tree/master/charts/dex/) version
-  targetRevision: "0.3.*"
+  targetRevision: "0.5.*"
   # dex.values -- Helm values
   # @default -- [upstream values](https://github.com/dexidp/helm-charts/tree/master/charts/dex/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Update dex Helm chart to 0.5.0 to update dex to v2.29.0.

## Changelog

Helm Chart:
* 0.4.0: Add support for configuring `priorityClassName`
* 0.5.0: Update dex to v2.29.0

Dex:
* [v2.29.0](https://github.com/dexidp/dex/releases/tag/v2.29.0): No relevant changes for us, but [#1846](https://github.com/dexidp/dex/pull/1846) add some features regarding refresh token handling.

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released