### PR TITLE
Add tail container and move securityContext configuration in huawei-csi-plugin

### DIFF
--- a/charts/huawei-csi-plugin/Chart.yaml
+++ b/charts/huawei-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: huawei-csi-plugin
 description: Deploy the Huawei CSI plugin
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: v2.2.RC3
 home: https://github.com/Huawei/eSDK_K8S_Plugin
 sources:

--- a/charts/huawei-csi-plugin/README.md
+++ b/charts/huawei-csi-plugin/README.md
@@ -1,6 +1,6 @@
 # huawei-csi-plugin
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.RC3](https://img.shields.io/badge/AppVersion-v2.2.RC3-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.RC3](https://img.shields.io/badge/AppVersion-v2.2.RC3-informational?style=flat-square)
 
 Deploy the Huawei CSI plugin
 
@@ -25,6 +25,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | csi_attacher.image.tag | string | `"v1.2.1"` | Image Tag for csi-attacher |
 | csi_attacher.resources | object | `{}` | resources for csi-attacher |
 | csi_driver.controller.resources | object | `{}` | resources for csi-driver container within controller-deployment |
+| csi_driver.controller.securityContext | object | - | securityContext for the huawei-csi-driver container in the controller deployment |
 | csi_driver.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-driver |
 | csi_driver.image.repository | string | `"ghcr.io/adfinis-sygroup/huawei-csi-plugin"` | Image Repo for csi-driver |
 | csi_driver.image.tag | string | `"v2.2.RC3"` | Image Tag for csi-driver |

--- a/charts/huawei-csi-plugin/templates/daemonset-node.yaml
+++ b/charts/huawei-csi-plugin/templates/daemonset-node.yaml
@@ -74,6 +74,19 @@ spec:
             - name: config-map
               mountPath: /etc/huawei
 
+        - name: tail
+          image: "{{ .Values.csi_driver.image.repository }}:{{ .Values.csi_driver.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.csi_driver.image.pullPolicy }}
+          command:
+            - "tail"
+            - "-F"
+            - "/var/log/huawei/huawei-csi-node"
+          securityContext:
+            {{- toYaml .Values.csi_driver.node.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: log-dir
+              mountPath: /var/log
+
       volumes:
         - name: plugin-dir
           hostPath:

--- a/charts/huawei-csi-plugin/templates/deployment-controller.yaml
+++ b/charts/huawei-csi-plugin/templates/deployment-controller.yaml
@@ -127,6 +127,19 @@ spec:
             - name: config-map
               mountPath: /etc/huawei
 
+        - name: tail
+          image: "{{ .Values.csi_driver.image.repository }}:{{ .Values.csi_driver.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.csi_driver.image.pullPolicy }}
+          command:
+            - "tail"
+            - "-F"
+            - "/var/log/huawei/huawei-csi-controller"
+          securityContext:
+            {{- toYaml .Values.csi_driver.node.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: log
+              mountPath: /var/log
+
       volumes:
         - name: socket-dir
           emptyDir:

--- a/charts/huawei-csi-plugin/templates/deployment-controller.yaml
+++ b/charts/huawei-csi-plugin/templates/deployment-controller.yaml
@@ -31,8 +31,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
       hostNetwork: true
       containers:
         - name: csi-provisioner
@@ -126,6 +124,8 @@ spec:
               mountPath: /var/log
             - name: config-map
               mountPath: /etc/huawei
+          securityContext:
+            {{- toYaml .Values.controller.securityContext | nindent 12 }}
 
         - name: tail
           image: "{{ .Values.csi_driver.image.repository }}:{{ .Values.csi_driver.image.tag | default .Chart.AppVersion }}"

--- a/charts/huawei-csi-plugin/values.yaml
+++ b/charts/huawei-csi-plugin/values.yaml
@@ -17,6 +17,11 @@ csi_driver:
     # csi_driver.image.pullPolicy -- Image PullPolicy for csi-driver
     pullPolicy: IfNotPresent
   controller:
+    # csi_driver.controller.securityContext -- securityContext for the huawei-csi-driver container in the controller deployment
+    # @default -- -
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
     # csi_driver.controller.resources -- resources for csi-driver container within controller-deployment
     resources: {}
   node:


### PR DESCRIPTION
# Description

Because the huawei-csi-driver image doesn't log to stdout I've added a tail container that will make the logs available via `kubectl logs`.

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
