### PR TITLE
fix(huawei-csi-plugin): use checksum/config annotation to automatically rollout config changes

### DIFF
--- a/charts/huawei-csi-plugin/Chart.yaml
+++ b/charts/huawei-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: huawei-csi-plugin
 description: Deploy the Huawei CSI plugin
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: v2.2.RC3
 home: https://github.com/Huawei/eSDK_K8S_Plugin
 sources:

--- a/charts/huawei-csi-plugin/README.md
+++ b/charts/huawei-csi-plugin/README.md
@@ -1,6 +1,6 @@
 # huawei-csi-plugin
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.RC3](https://img.shields.io/badge/AppVersion-v2.2.RC3-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.RC3](https://img.shields.io/badge/AppVersion-v2.2.RC3-informational?style=flat-square)
 
 Deploy the Huawei CSI plugin
 

--- a/charts/huawei-csi-plugin/templates/daemonset-node.yaml
+++ b/charts/huawei-csi-plugin/templates/daemonset-node.yaml
@@ -13,10 +13,9 @@ spec:
       app.kubernetes.io/component: "csi-node"
   template:
     metadata:
-       {{- with .Values.node.podAnnotations }}
        annotations:
-         {{- toYaml . | nindent 8 }}
-       {{- end }}
+         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+         {{- toYaml .Values.node.podAnnotations | nindent 8 }}
       labels:
         {{- include "huawei-csi-plugin.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "csi-node"

--- a/charts/huawei-csi-plugin/templates/daemonset-node.yaml
+++ b/charts/huawei-csi-plugin/templates/daemonset-node.yaml
@@ -15,7 +15,9 @@ spec:
     metadata:
        annotations:
          checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-         {{- toYaml .Values.node.podAnnotations | nindent 8 }}
+         {{- with .Values.node.podAnnotations }}
+         {{- toYaml . | nindent 8 }}
+         {{- end }}
       labels:
         {{- include "huawei-csi-plugin.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "csi-node"

--- a/charts/huawei-csi-plugin/templates/daemonset-node.yaml
+++ b/charts/huawei-csi-plugin/templates/daemonset-node.yaml
@@ -13,11 +13,11 @@ spec:
       app.kubernetes.io/component: "csi-node"
   template:
     metadata:
-       annotations:
-         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-         {{- with .Values.node.podAnnotations }}
-         {{- toYaml . | nindent 8 }}
-         {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.node.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "huawei-csi-plugin.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "csi-node"

--- a/charts/huawei-csi-plugin/templates/deployment-controller.yaml
+++ b/charts/huawei-csi-plugin/templates/deployment-controller.yaml
@@ -20,7 +20,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
+        {{- with .Values.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "huawei-csi-plugin.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "csi-controller"

--- a/charts/huawei-csi-plugin/templates/deployment-controller.yaml
+++ b/charts/huawei-csi-plugin/templates/deployment-controller.yaml
@@ -18,10 +18,9 @@ spec:
       app.kubernetes.io/component: "csi-controller"
   template:
     metadata:
-    {{- with .Values.controller.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
       labels:
         {{- include "huawei-csi-plugin.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "csi-controller"


### PR DESCRIPTION
# Description

Add checksum/config annotation to controller deployment and node daemonset to trigger a restart when the configuration changes.

# Issues

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released