### PR TITLE
Fix for openshift-etcd-backup cronjob

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: v1.4.0
 keywords:
   - openshift-etcd-backup

--- a/charts/openshift-etcd-backup/templates/cronjob.yaml
+++ b/charts/openshift-etcd-backup/templates/cronjob.yaml
@@ -3,6 +3,7 @@ kind: CronJob
 metadata:
   name: {{ include "openshift-etcd-backup.fullname" . }}
 spec:
+  startingDeadlineSeconds: 600
   schedule: {{ .Values.backup.schedule | quote }}
   jobTemplate:
     spec:


### PR DESCRIPTION
# Description

For every CronJob, the CronJob Controller checks how many schedules it missed in the duration from its last scheduled time until now. If there are more than 100 missed schedules, then it does not start the job and logs the error. If the value is set, the cronjob will survive a cluster downtime.

See: https://access.redhat.com/solutions/3667021 and kubernetes/kubernetes#42649 for details

# Checklist


* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
