### PR TITLE
feat(timed): add static file volume

### DIFF
--- a/.github/workflows/pr-sizing.yaml
+++ b/.github/workflows/pr-sizing.yaml
@@ -1,7 +1,7 @@
 ## Reference: https://github.com/pascalgn/size-label-action
 ---
 name: 'PR Size'
-on: 
+on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 jobs:

--- a/charts/infra-apps/examples/thanos.yaml
+++ b/charts/infra-apps/examples/thanos.yaml
@@ -1,7 +1,7 @@
 # Deploy Thanos
 #
-# This takes care of deploying Thanos' store gateway, query frontend, and receiver. 
-# Usually the prometheus-operator from kube-prometheus-stack will deploy 
+# This takes care of deploying Thanos' store gateway, query frontend, and receiver.
+# Usually the prometheus-operator from kube-prometheus-stack will deploy
 # ThanosRulers and sidecars to complete the stack.
 
 thanos:

--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 description: Chart for Timed application
 type: application
-version: 0.7.2
+version: 0.8.0
 appVersion: v1.3.0
 keywords:
   - timed

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -1,6 +1,6 @@
 # timed
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Chart for Timed application
 

--- a/charts/timed/templates/deployment-backend.yaml
+++ b/charts/timed/templates/deployment-backend.yaml
@@ -40,6 +40,9 @@ spec:
             - name: workreport
               mountPath: {{ .Values.backend.settings.workReportPath }}
               subPath: workreport
+            - name: staticfiles
+              mountPath: /var/www/static
+              subPath: staticfiles
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           ports:
             - name: http
@@ -82,3 +85,6 @@ spec:
         - name: workreport
           configMap:
             name: {{ include "timed.fullname" .}}-workreport
+        - name: staticfiles
+          configMap:
+            name: {{ include "timed.fullname" .}}-staticfiles

--- a/charts/timed/templates/deployment-frontend.yaml
+++ b/charts/timed/templates/deployment-frontend.yaml
@@ -27,6 +27,10 @@ spec:
             - name: http
               containerPort: {{ .Values.frontend.service.internalPort }}
           {{- if .Values.frontend.livenessProbe.enabled }}
+          volumeMounts:
+            - name: staticfiles
+              mountPath: /var/www/html/static
+              subPath: staticfiles
           livenessProbe:
             initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds }}
@@ -54,3 +58,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.frontend.nodeSelector | indent 8 }}
     {{- end }}
+      volumes:
+        - name: staticfiles
+          configMap:
+            name: {{ include "timed.fullname" .}}-staticfiles


### PR DESCRIPTION
The timed backend (especially the admin section) needs some static files
to work.  Given Django best-practices, it is not recommended for the
static files to be served by Django itself, but rather by a dedicated
web server.

This creates a volume for the static files, which can then be shared with
the frontend web server, which already provides the application assets.

The static files are generated by the startup script of the backend
container, so they will be freshly written any time the conainer comes
up. We don't need to worry about them being stale etc.

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [ ] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
