### PR TITLE
feat(security-apps): upgrade secrets-store-csi-driver to 0.3.*

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.28.0
-appVersion: 0.28.0
+version: 0.29.0
+appVersion: 0.29.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.28.0](https://img.shields.io/badge/AppVersion-0.28.0-informational?style=flat-square)
+![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.0](https://img.shields.io/badge/AppVersion-0.29.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -62,9 +62,9 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | secretsStoreCsiDriver.chart | string | `"secrets-store-csi-driver"` | Chart |
 | secretsStoreCsiDriver.destination.namespace | string | `"infra-secrets-store-csi"` | Namespace |
 | secretsStoreCsiDriver.enabled | bool | `false` | Enable secrets-store-csi-driver |
-| secretsStoreCsiDriver.repoURL | string | [repo](https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts) | Repo URL |
-| secretsStoreCsiDriver.targetRevision | string | `"0.1.*"` | [vault-csi-provider Helm chart](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver) version |
-| secretsStoreCsiDriver.values | object | [upstream values](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver/values.yaml) | Helm values |
+| secretsStoreCsiDriver.repoURL | string | [repo](https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts) | Repo URL |
+| secretsStoreCsiDriver.targetRevision | string | `"0.3.*"` | [vault-csi-provider Helm chart](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver) version |
+| secretsStoreCsiDriver.values | object | [upstream values](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/values.yaml) | Helm values |
 | vault | object | - | [vault](https://github.com/hashicorp/vault/) ([example](./examples/vault.yaml)) |
 | vault.chart | string | `"vault"` | Chart |
 | vault.destination.namespace | string | `"infra-vault"` | Namespace |

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -148,12 +148,12 @@ secretsStoreCsiDriver:
     # secretsStoreCsiDriver.destination.namespace -- Namespace
     namespace: "infra-secrets-store-csi"
   # secretsStoreCsiDriver.repoURL -- Repo URL
-  # @default -- [repo](https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts)
-  repoURL: "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts"
+  # @default -- [repo](https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts)
+  repoURL: "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"
   # secretsStoreCsiDriver.chart -- Chart
   chart: "secrets-store-csi-driver"
-    # secretsStoreCsiDriver.targetRevision -- [vault-csi-provider Helm chart](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver) version
-  targetRevision: "0.1.*"
+    # secretsStoreCsiDriver.targetRevision -- [vault-csi-provider Helm chart](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver) version
+  targetRevision: "0.3.*"
   # secretsStoreCsiDriver.values -- Helm values
-  # @default -- [upstream values](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver/values.yaml)
+  # @default -- [upstream values](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Upgrade from v0.1 to v0.3

Release notes:
https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.3.0
https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.2.0

BREAKING CHANGES new helm chart repo URL and more stuff linked above!

# Issue

Closes https://github.com/adfinis-sygroup/helm-charts/issues/345

# Possible issues

Manual upgrade procedure in case of failure:
https://secrets-store-csi-driver.sigs.k8s.io/getting-started/upgrades.html#upgrades

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
