### PR TITLE
chore(misc-apps): metallb use official helm repo

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.9.0
+appVersion: 0.9.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -41,9 +41,9 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | metallb.chart | string | `"metallb"` | Chart |
 | metallb.destination.namespace | string | `"infra-metallb"` | Namespace |
 | metallb.enabled | bool | `false` | Enable metallb |
-| metallb.repoURL | string | [repo](https://charts.bitnami.com/bitnami) | Repo URL |
-| metallb.targetRevision | string | `"2.4.*"` | [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb) |
-| metallb.values | object | [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/metallb/values.yaml) | Helm values |
+| metallb.repoURL | string | [repo](https://metallb.github.io/metallb) | Repo URL |
+| metallb.targetRevision | string | `"0.10.*"` | [metallb Helm chart](https://github.com/metallb/metallb/tree/main/charts/metallb) |
+| metallb.values | object | [upstream values](https://github.com/metallb/metallb/blob/main/charts/metallb/values.yaml) | Helm values |
 | sentryKubernetes | object | - | [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml) |
 | sentryKubernetes.chart | string | `"sentry-kubernetes"` | Chart |
 | sentryKubernetes.destination.namespace | string | `"infra-sentry-kubernetes"` | Namespace |

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 

--- a/charts/misc-apps/examples/metallb.yaml
+++ b/charts/misc-apps/examples/metallb.yaml
@@ -2,10 +2,8 @@ metallb:
   enabled: true
   project: infra-metallb
   values:
-    prometheus:
-      enabled: true
-      serviceMonitor:
-        enabled: true
+    psp:
+      create: false
     configInline:
       address-pools:
         - name: default

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -68,14 +68,14 @@ metallb:
     # metallb.destination.namespace -- Namespace
     namespace: "infra-metallb"
   # metallb.repoURL -- Repo URL
-  # @default -- [repo](https://charts.bitnami.com/bitnami)
-  repoURL: "https://charts.bitnami.com/bitnami"
+  # @default -- [repo](https://metallb.github.io/metallb)
+  repoURL: "https://metallb.github.io/metallb"
   # metallb.chart -- Chart
   chart: "metallb"
-  # metallb.targetRevision -- [metallb Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb)
-  targetRevision: "2.4.*"
+  # metallb.targetRevision -- [metallb Helm chart](https://github.com/metallb/metallb/tree/main/charts/metallb)
+  targetRevision: "0.10.*"
   # metallb.values -- Helm values
-  # @default -- [upstream values](https://github.com/bitnami/charts/tree/master/bitnami/metallb/values.yaml)
+  # @default -- [upstream values](https://github.com/metallb/metallb/blob/main/charts/metallb/values.yaml)
   values: {}
 
 # chartmuseum -- [chartmuseum](https://chartmuseum.com) ([example](./example/chartmuseum.yaml))


### PR DESCRIPTION
# Description

Updates `misc-apps/metallb` to use the official helm repo with chart version `0.10.*`

According to the [release notes](https://metallb.universe.tf/release-notes/#version-0-10-0) 

`You should be able to migrate from Bitnami Charts to MetalLB Charts by just changing the repo and upgrading.` 

But the values between the [bitnami chart](https://github.com/bitnami/charts/tree/master/bitnami/metallb) and the [official chart
](https://github.com/metallb/metallb/tree/main/charts/metallb) differs slightly so I suggest you review your own values before upgrading.

# Issues

Fixes #341 
Fixes #365 

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
