### PR TITLE
fix(timed): remove duplicate label and cleanup docs

### DIFF
--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 description: Chart for Timed application
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: v1.3.0
 keywords:
   - timed

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -1,6 +1,6 @@
 # timed
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Chart for Timed application
 
@@ -57,6 +57,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | backend.cronjobs.redmineReport | object | `{"command":["./manage.py","redmine_report"],"schedule":"0 1 * * 1"}` | Redmine report |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | Backend image pull policy |
 | backend.image.repository | string | `"adfinissygroup/timed-backend"` | Backend image name |
+| backend.image.tag | string | `"v1.3.0"` | Backend version (optional) in case it differs from appVersion in Chart.yaml |
 | backend.livenessProbe.enabled | bool | `true` | Enable liveness probe on backend |
 | backend.livenessProbe.failureThreshold | int | `6` | Number of tries to perform the probe |
 | backend.livenessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before liveness probe is initiated |
@@ -88,7 +89,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | backend.settings.workReportPath | string | `"/etc/workreport"` | Path where the workreport shall be loaded from. The contents of the default path is filled from `configmap-workreport.yaml`. |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | Frontend image pull policy |
 | frontend.image.repository | string | `"adfinissygroup/timed-frontend"` | Frontend image name |
-| frontend.image.tag | string | `"v1.1.3"` | Frontend version (optional) in case it differs from backend |
+| frontend.image.tag | string | `"v1.3.1"` | Frontend version (optional) in case it differs from appVersion in Chart.yaml |
 | frontend.livenessProbe.enabled | bool | `true` | Enable liveness probe on frontend |
 | frontend.livenessProbe.failureThreshold | int | `6` | Number of tries to perform the probe |
 | frontend.livenessProbe.initialDelaySeconds | int | `60` | Number of seconds after the container has started before liveness probe is initiated |

--- a/charts/timed/templates/_helpers.tpl
+++ b/charts/timed/templates/_helpers.tpl
@@ -39,7 +39,6 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ .Chart.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ include "timed.selectorLabels" . }}
 {{- end -}}
 

--- a/charts/timed/values.yaml
+++ b/charts/timed/values.yaml
@@ -7,9 +7,7 @@ backend:
   image:
     # backend.image.repository -- Backend image name
     repository: adfinissygroup/timed-backend
-     # Specify a tag to override which version of timed to deploy.
-     # If no tag is specified the appVersion from Chart.yaml is used as tag.
-    # backend.image.tag -- Backend image tag
+    # backend.image.tag -- Backend version (optional) in case it differs from appVersion in Chart.yaml
     tag: v1.3.0
     # backend.image.pullPolicy -- Backend image pull policy
     pullPolicy: IfNotPresent
@@ -150,12 +148,9 @@ frontend:
   image:
     # frontend.image.repository -- Frontend image name
     repository: adfinissygroup/timed-frontend
-    # Specify a tag to override which version of timed to deploy.
-    # If no tag is specified the appVersion from Chart.yaml is used as tag.
-    # tag:
     # frontend.image.pullPolicy -- Frontend image pull policy
     pullPolicy: IfNotPresent
-    # frontend.image.tag -- Frontend version (optional) in case it differs from backend
+    # frontend.image.tag -- Frontend version (optional) in case it differs from appVersion in Chart.yaml
     tag: v1.3.1
   service:
     # frontend.service.name -- Frontend service name


### PR DESCRIPTION
# Description
Removes a duplicate `app.kubernetes.io/managed-by` label from _helpers.tpl and regenrates the docs with some small consistency fixes.

# Issues

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released