### PR TITLE
fix(timed): use sync waves for db migrations

### DIFF
--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 description: Chart for Timed application
 type: application
-version: 0.7.5
+version: 0.7.6
 appVersion: v1.3.0
 keywords:
   - timed

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -1,6 +1,6 @@
 # timed
 
-![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 Chart for Timed application
 

--- a/charts/timed/templates/cronjob-backend.yaml
+++ b/charts/timed/templates/cronjob-backend.yaml
@@ -8,6 +8,8 @@ metadata:
   labels:
     {{- include "timed.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $key | lower | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   schedule: {{ $val.schedule | quote }}
   concurrencyPolicy: Forbid

--- a/charts/timed/templates/deployment-backend.yaml
+++ b/charts/timed/templates/deployment-backend.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "timed.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   replicas: {{ .Values.backend.replicaCount }}
   selector:

--- a/charts/timed/templates/deployment-frontend.yaml
+++ b/charts/timed/templates/deployment-frontend.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "timed.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   replicas: {{ .Values.frontend.replicaCount }}
   selector:

--- a/charts/timed/templates/job-dbmigrate.yaml
+++ b/charts/timed/templates/job-dbmigrate.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "timed.labels" . | nindent 4 }}
     app.kubernetes.io/component: db-migrate
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   activeDeadlineSeconds: 300
   template:


### PR DESCRIPTION
# Description

Sync timed in waves when using Argo CD:
* first wave deploys the database, secrets, configmaps, services and similar things
* second wave runs db migrations (as a `Sync` hook so they get run on each sync)
* third wave deploys (or updates) the backend and frontend Deployments as well as CronJobs (after the db has been created/migrated)

# Issues
Fixes #12

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released