### PR TITLE
fix(openshift-etcd-backup): use capabilites instead of kubernetesVersion check

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.5.1
+version: 1.5.2
 appVersion: v1.5.2
 keywords:
   - openshift-etcd-backup

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.2](https://img.shields.io/badge/AppVersion-v1.5.2-informational?style=flat-square)
+![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.2](https://img.shields.io/badge/AppVersion-v1.5.2-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 
@@ -30,7 +30,6 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | image.pullPolicy | string | `"Always"` | Image pull policy configuration |
 | image.repository | string | `"ghcr.io/adfinis-sygroup/openshift-etcd-backup"` | Repository image to use |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| kubeVersionOverride | string | `nil` | override what version of Kubernetes to render against |
 | monitoring.additionalRules | string | `nil` | Provide custom recording or alerting rules to be deployed into the cluster. |
 | monitoring.enabled | bool | `false` | Deploy PrometheusRule to be alerted in case of backup fails as decribed [here](https://github.com/adfinis-sygroup/openshift-etcd-backup/blob/main/etcd-backup-cronjob-monitor.PrometheusRule.yaml). Be sure to to have monitoring for user defined projects enabled as [described in the upstream documentation](https://docs.openshift.com/container-platform/4.6/monitoring/enabling-monitoring-for-user-defined-projects.html). |
 | monitoring.rules.cronjobMonitor | bool | `true` | Deploy PrometheusRule to check for cronjob fails. |

--- a/charts/openshift-etcd-backup/templates/cronjob.yaml
+++ b/charts/openshift-etcd-backup/templates/cronjob.yaml
@@ -1,9 +1,7 @@
-{{- $kubeVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride }}
----
-{{- if semverCompare "<1.21-0" $kubeVersion }}
-apiVersion: batch/v1beta1
-{{- else }}
+{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
 apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
 {{- end }}
 kind: CronJob
 metadata:

--- a/charts/openshift-etcd-backup/values.yaml
+++ b/charts/openshift-etcd-backup/values.yaml
@@ -2,9 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# kubeVersionOverride -- override what version of Kubernetes to render against
-kubeVersionOverride: ~
-
 backup:
   # -- Sub directory path
   subdir: "/"


### PR DESCRIPTION
Signed-off-by: Valentin Maillot <valentin.maillot@adfinis.com>

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
Use `.Capabilities.APIVersions.Has "batch/v1/CronJob"` instead of comparing Kubernetes version.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
