### PR TITLE
fix(argocd): Capabilities.APIVersion condition

### DIFF
--- a/charts/back8sup/Chart.yaml
+++ b/charts/back8sup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: back8sup
 description: Deploy back8sup to a Kubernetes Cluster
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: v0.7.5
 home: https://github.com/adfinis-sygroup/back8sup
 sources:

--- a/charts/back8sup/README.md
+++ b/charts/back8sup/README.md
@@ -1,6 +1,6 @@
 # back8sup
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.5](https://img.shields.io/badge/AppVersion-v0.7.5-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.5](https://img.shields.io/badge/AppVersion-v0.7.5-informational?style=flat-square)
 
 Deploy back8sup to a Kubernetes Cluster
 

--- a/charts/back8sup/templates/cronjob.yaml
+++ b/charts/back8sup/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+{{- if .Capabilities.APIVersions.Has "batch/v1" }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1

--- a/charts/customer-center/Chart.yaml
+++ b/charts/customer-center/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: customer-center
 description: Chart for Customer-Center application
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: v2.1.1
 keywords:
   - customer-center

--- a/charts/customer-center/README.md
+++ b/charts/customer-center/README.md
@@ -1,6 +1,6 @@
 # customer-center
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.1](https://img.shields.io/badge/AppVersion-v2.1.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.1](https://img.shields.io/badge/AppVersion-v2.1.1-informational?style=flat-square)
 
 Chart for Customer-Center application
 

--- a/charts/customer-center/templates/ingress.yaml
+++ b/charts/customer-center/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "customerCenter.fullname" . }}
 {{- $backendExternalPort := .Values.backend.service.externalPort }}
 {{- $frontendExternalPort := .Values.frontend.service.externalPort }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.5.2
-appVersion: v1.5.2
+version: 1.5.3
+appVersion: v1.5.3
 keywords:
   - openshift-etcd-backup
   - openshift

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.2](https://img.shields.io/badge/AppVersion-v1.5.2-informational?style=flat-square)
+![Version: 1.5.3](https://img.shields.io/badge/Version-1.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.3](https://img.shields.io/badge/AppVersion-v1.5.3-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 

--- a/charts/openshift-etcd-backup/templates/cronjob.yaml
+++ b/charts/openshift-etcd-backup/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+{{- if .Capabilities.APIVersions.Has "batch/v1" }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1

--- a/charts/rmd/Chart.yaml
+++ b/charts/rmd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rmd
 description: Chart for Rmd.io application
 type: application
-version: 0.1.14
+version: 0.1.15
 appVersion: edge
 keywords:
   - rmd

--- a/charts/rmd/README.md
+++ b/charts/rmd/README.md
@@ -1,6 +1,6 @@
 # rmd
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: edge](https://img.shields.io/badge/AppVersion-edge-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: edge](https://img.shields.io/badge/AppVersion-edge-informational?style=flat-square)
 
 Chart for Rmd.io application
 

--- a/charts/rmd/templates/cronjob.yaml
+++ b/charts/rmd/templates/cronjob.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $val := .Values.rmd.cronjobs }}
 ---
-{{- if $.Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+{{- if $.Capabilities.APIVersions.Has "batch/v1" }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1


### PR DESCRIPTION


# Description

Fix Capabilities.APIVersion condition
    
In case this problem persists, we recommend to restart redis or all ArgoCD Pods,
as ArgoCD needs a restart to pass the right --api-versions to the helm template

# Issues

`.Capabilities.APIVersions.Has` not doing proper condition.

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
