### PR TITLE
chore(back8sup): fix CronJob apiVersion with K8s version

### DIFF
--- a/charts/back8sup/Chart.yaml
+++ b/charts/back8sup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: back8sup
 description: Deploy back8sup to a Kubernetes Cluster
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: v0.7.5
 home: https://github.com/adfinis-sygroup/back8sup
 sources:

--- a/charts/back8sup/README.md
+++ b/charts/back8sup/README.md
@@ -1,6 +1,6 @@
 # back8sup
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.5](https://img.shields.io/badge/AppVersion-v0.7.5-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.5](https://img.shields.io/badge/AppVersion-v0.7.5-informational?style=flat-square)
 
 Deploy back8sup to a Kubernetes Cluster
 
@@ -43,6 +43,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | image.repository | string | `"ghcr.io/adfinis-sygroup/back8sup"` | set the image repository |
 | image.tag | string | `""` | set the tag of the image Specify a tag to override which version of timed to deploy. If no tag is specified the appVersion from Chart.yaml is used as tag. |
 | imagePullSecrets | list | `[]` | specifies the image pull secrets to be used |
+| kubeVersionOverride | string | `nil` | override what version of Kubernetes to render against |
 | nameOverride | string | `""` | specifies the name override to be used for helm |
 | nodeSelector | object | `{}` | specifies the nodeSelector to be used |
 | persistence.enabled | bool | `true` | specifies if persistence is enabled or not |

--- a/charts/back8sup/templates/cronjob.yaml
+++ b/charts/back8sup/templates/cronjob.yaml
@@ -1,7 +1,8 @@
-{{- if .Capabilities.APIVersions.Has "batch/v1" }}
-apiVersion: batch/v1
-{{- else }}
+{{- $kubeVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride }}
+{{- if semverCompare "<1.21-0" $kubeVersion }}
 apiVersion: batch/v1beta1
+{{- else }}
+apiVersion: batch/v1
 {{- end }}
 kind: CronJob
 metadata:

--- a/charts/back8sup/values.yaml
+++ b/charts/back8sup/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# kubeVersionOverride -- override what version of Kubernetes to render against
+kubeVersionOverride: ~
+
 # replicaCount -- specifies the replica count of the pods
 replicaCount: 1
 


### PR DESCRIPTION
Signed-off-by: Valentin Maillot <valentin.maillot@adfinis.com>

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
Fix how we setup the correct apiVersion for CronJob manifest.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
