### PR TITLE
fix(cert-manager-monitoring): configurable job label for CertManagerAbsent

### DIFF
--- a/charts/cert-manager-monitoring/Chart.yaml
+++ b/charts/cert-manager-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cert-manager-monitoring
 description: Monitor cert-manager with cert-manager-mixin.
 type: application
-version: 0.1.0
+version: 0.1.1
 keywords:
   - cert-manager
   - tls

--- a/charts/cert-manager-monitoring/README.md
+++ b/charts/cert-manager-monitoring/README.md
@@ -1,6 +1,6 @@
 # cert-manager-monitoring
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Monitor cert-manager with cert-manager-mixin.
 
@@ -26,6 +26,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | prometheus.enabled | bool | `true` | Create prometheus-operator resources |
 | prometheus.rule.additionalAlerts | list | `[]` | Add additional alerts to the cert-manager group |
 | prometheus.rule.additionalLabels | object | `{}` | Additional Labels for PrometheusRule resource |
+| prometheus.rule.alertConfigs.absent.job | string | `"cert-manager"` | Configure job label for CertManagerAbsent alert.<F12 |
 | prometheus.rule.alerts.absent | bool | `true` | Enable CertManagerAbsent alert |
 | prometheus.rule.alerts.certnotready | bool | `true` | Enable CertManagerCertNotReady alert |
 | prometheus.rule.alerts.expirysoon | bool | `true` | Enable CertManagerExpirySoon alert |

--- a/charts/cert-manager-monitoring/README.md
+++ b/charts/cert-manager-monitoring/README.md
@@ -26,7 +26,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | prometheus.enabled | bool | `true` | Create prometheus-operator resources |
 | prometheus.rule.additionalAlerts | list | `[]` | Add additional alerts to the cert-manager group |
 | prometheus.rule.additionalLabels | object | `{}` | Additional Labels for PrometheusRule resource |
-| prometheus.rule.alertConfigs.absent.job | string | `"cert-manager"` | Configure job label for CertManagerAbsent alert.<F12 |
+| prometheus.rule.alertConfigs.absent.job | string | `"cert-manager"` | Configure job label for CertManagerAbsent alert. |
 | prometheus.rule.alerts.absent | bool | `true` | Enable CertManagerAbsent alert |
 | prometheus.rule.alerts.certnotready | bool | `true` | Enable CertManagerCertNotReady alert |
 | prometheus.rule.alerts.expirysoon | bool | `true` | Enable CertManagerExpirySoon alert |

--- a/charts/cert-manager-monitoring/templates/prometheus/prometheusrule.yaml
+++ b/charts/cert-manager-monitoring/templates/prometheus/prometheusrule.yaml
@@ -17,7 +17,7 @@ spec:
     rules:
     {{- if .Values.prometheus.rule.alerts.absent }}
     - alert: CertManagerAbsent
-      expr: absent(up{job="cert-manager"})
+      expr: absent(up{job="{{ .Values.prometheus.rule.alertConfigs.absent.job }}"})
       for: 10m
       annotations:
         summary: Cert Manager has dissapeared from Prometheus service discovery.

--- a/charts/cert-manager-monitoring/values.yaml
+++ b/charts/cert-manager-monitoring/values.yaml
@@ -17,6 +17,10 @@ prometheus:
       certnotready: true
       # -- Enable CertManagerHittingRateLimits alert
       hittingratelimits: true
+    alertConfigs:
+      absent:
+        # -- Configure job label for CertManagerAbsent alert.<F12
+        job: "cert-manager"
     # -- Add additional alerts to the cert-manager group
     additionalAlerts: []
     # - alert: CertManagerCertificateReadyStatus

--- a/charts/cert-manager-monitoring/values.yaml
+++ b/charts/cert-manager-monitoring/values.yaml
@@ -19,7 +19,7 @@ prometheus:
       hittingratelimits: true
     alertConfigs:
       absent:
-        # -- Configure job label for CertManagerAbsent alert.<F12
+        # -- Configure job label for CertManagerAbsent alert.
         job: "cert-manager"
     # -- Add additional alerts to the cert-manager group
     additionalAlerts: []


### PR DESCRIPTION
# Description

Allow us to configure the `job` in the `CertManagerAbsent` alert to use something that is not `cert-manager`.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
