### PR TITLE
fix(openshift-etcd-backup): app-version should be 1.5.2

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.5.4
-appVersion: v1.5.3
+version: 1.5.5
+appVersion: v1.5.2
 keywords:
   - openshift-etcd-backup
   - openshift

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.3](https://img.shields.io/badge/AppVersion-v1.5.3-informational?style=flat-square)
+![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.2](https://img.shields.io/badge/AppVersion-v1.5.2-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 


### PR DESCRIPTION
Signed-off-by: Valentin Maillot <valentin.maillot@adfinis.com>

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
We bumped by mistake the `appVersion` of this chart in this [commit](https://github.com/adfinis-sygroup/helm-charts/commit/bf617fc8f985566dfda9ad53abb0b18fd21ff35c#diff-c89b3823e7eba09ba99808c297e564d3acb63e3a775bbdcb36c743d5901ed4f7).
But there are no such image available which provides an error while deploying the chart.

Please see Dockerhub links:

* https://hub.docker.com/r/adfinissygroup/openshift-etcd-backup/tags?page=1&name=1.5.3
* https://hub.docker.com/r/adfinissygroup/openshift-etcd-backup/tags?page=1&name=1.5.2 (which is the latest)
* https://github.com/adfinis-sygroup/openshift-etcd-backup/releases

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
