### PR TITLE
chore: mark sentry-apps as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ for more in-depth information.
 | [logging-apps](charts/logging-apps) | Argo CD app-of-apps config for logging applications | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) |
 | [misc-apps](charts/misc-apps) | Argo CD app-of-apps config for miscellaneous small tools | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) |
 | [security-apps](charts/security-apps) | Argo CD app-of-apps config for security applications | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) |
-| [sentry-apps](charts/sentry-apps) | Sentry on premise | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) |
 | [storage-apps](charts/storage-apps) | Argo CD app-of-apps config for storage applications | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) |
 | [tracing-apps](charts/tracing-apps) | Argo CD app-of-apps config for tracing applications | ![Version: 0.x](https://img.shields.io/badge/version-0.x-brightgreen) |
 

--- a/charts/sentry-apps/Chart.yaml
+++ b/charts/sentry-apps/Chart.yaml
@@ -1,16 +1,13 @@
 apiVersion: v2
 name: sentry-apps
-description: Sentry on premise
+description: ⚠️ (OBSOLETE) use https://github.com/sentry-kubernetes/charts directly instead
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: 5.1.2
+deprecated: true
 home: https://github.com/sentry-kubernetes/charts/tree/develop/sentry
 sources:
   - https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/sentry-apps
-maintainers:
-  - name: adfinis-sygroup
-    email: support@adfinis.com
-    url: https://adfinis.com
 dependencies:
   - name: argoconfig
     repository: https://charts.adfinis.com

--- a/charts/sentry-apps/README.md
+++ b/charts/sentry-apps/README.md
@@ -1,13 +1,12 @@
 # sentry-apps
 
-![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.1.2](https://img.shields.io/badge/AppVersion-5.1.2-informational?style=flat-square)
+> **:exclamation: This Helm Chart is deprecated!**
 
-Sentry on premise
+![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.1.2](https://img.shields.io/badge/AppVersion-5.1.2-informational?style=flat-square)
+
+⚠️ (OBSOLETE) use https://github.com/sentry-kubernetes/charts directly instead
 
 **Homepage:** <https://github.com/sentry-kubernetes/charts/tree/develop/sentry>
-
-## Maintainers
-This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk_kwd=helm-charts).
 
 ## Source Code
 


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Deprecate the `sentry-apps` app of apps wrapper chart. Users can either use the [wrapped charts](https://github.com/sentry-kubernetes/charts) directly, Sentry SaaS or GitLab.

I will do a policy bypass to get this merged once approved, we do not want to put any effort into making CI green for this deprecation.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [ ]  ❌ CI is currently green ❌
* [x] this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
