### PR TITLE
feat(infra-apps): kube-prometheus-stack 21.0

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -3,8 +3,8 @@ name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
 # version and appVersion are in sync in this chart!
-version: 0.60.0
-appVersion: 0.60.0
+version: 0.61.0
+appVersion: 0.61.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/infra-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.60.0](https://img.shields.io/badge/Version-0.60.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.60.0](https://img.shields.io/badge/AppVersion-0.60.0-informational?style=flat-square)
+![Version: 0.61.0](https://img.shields.io/badge/Version-0.61.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.61.0](https://img.shields.io/badge/AppVersion-0.61.0-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -77,7 +77,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.destination.namespace | string | `"infra-monitoring"` | Namespace |
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
-| kubePrometheusStack.targetRevision | string | `"19.2.*"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"21.0.*"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/weaveworks/kured) |
 | kured.chart | string | `"kured"` | Chart |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -134,7 +134,7 @@ kubePrometheusStack:
   # kubePrometheusStack.chart -- Chart
   chart: "kube-prometheus-stack"
   # kubePrometheusStack.targetRevision -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: '19.2.*'
+  targetRevision: '21.0.*'
   # kubePrometheusStack.values -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

- separate values for config reloader limit and request https://github.com/prometheus-community/helm-charts/pull/1375
- bump alertmanager to 0.23.0 https://github.com/prometheus-community/helm-charts/pull/1397
- bump thanos to 0.23.1 https://github.com/prometheus-community/helm-charts/pull/1397
- bump prometheus to 2.31.1 https://github.com/prometheus-community/helm-charts/pull/1397
- bump prometheus-operator to 0.52.0 https://github.com/prometheus-community/helm-charts/pull/1485
- bump promehtues-config-reloader to 0.52.0 https://github.com/prometheus-community/helm-charts/pull/1485

The prometheus-operator change contains a CRD update which argo cd
should sync where this is used.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run -a`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
