### PR TITLE
chore(*-apps): get rid of redundant version info

### DIFF
--- a/charts/azure-apps/Chart.yaml
+++ b/charts/azure-apps/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: azure-apps
 description: Argo CD app-of-apps config for Azure applications
 type: application
-# version and appVersion are in sync in this chart!
-version: 0.2.1
-appVersion: 0.2.1
+version: 0.2.2
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/azure-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/azure-apps/README.md
+++ b/charts/azure-apps/README.md
@@ -1,6 +1,6 @@
 # azure-apps
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for Azure applications
 

--- a/charts/backup-apps/Chart.yaml
+++ b/charts/backup-apps/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: backup-apps
 description: Argo CD app-of-apps config for backup components
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/backup-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/backup-apps/README.md
+++ b/charts/backup-apps/README.md
@@ -1,6 +1,6 @@
 # backup-apps
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for backup components
 

--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-# version and appVersion are in sync in this chart!
-version: 0.67.0
-appVersion: 0.67.0
+version: 0.67.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/infra-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.67.0](https://img.shields.io/badge/Version-0.67.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.67.0](https://img.shields.io/badge/AppVersion-0.67.0-informational?style=flat-square)
+![Version: 0.67.1](https://img.shields.io/badge/Version-0.67.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 

--- a/charts/logging-apps/Chart.yaml
+++ b/charts/logging-apps/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: logging-apps
 description: Argo CD app-of-apps config for logging applications
 type: application
-# version and appVersion are in sync in this chart!
-version: 0.14.0
-appVersion: 0.14.0
+version: 0.14.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/logging-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/logging-apps/README.md
+++ b/charts/logging-apps/README.md
@@ -1,6 +1,6 @@
 # logging-apps
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for logging applications
 

--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
-# version and appVersion are in sync in this chart!
-version: 0.13.0
-appVersion: 0.13.0
+version: 0.13.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 

--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
-# version and appVersion are in sync in this chart!
-version: 0.38.0
-appVersion: 0.38.0
+version: 0.38.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.38.0](https://img.shields.io/badge/Version-0.38.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.0](https://img.shields.io/badge/AppVersion-0.38.0-informational?style=flat-square)
+![Version: 0.38.1](https://img.shields.io/badge/Version-0.38.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 

--- a/charts/storage-apps/Chart.yaml
+++ b/charts/storage-apps/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: storage-apps
 description: Argo CD app-of-apps config for storage applications
 type: application
-# version and appVersion are in sync in this chart!
-version: 0.5.0
-appVersion: 0.5.0
+version: 0.5.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/storage-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/storage-apps/README.md
+++ b/charts/storage-apps/README.md
@@ -1,6 +1,6 @@
 # storage-apps
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for storage applications
 

--- a/charts/tracing-apps/Chart.yaml
+++ b/charts/tracing-apps/Chart.yaml
@@ -2,9 +2,7 @@ apiVersion: v2
 name: tracing-apps
 description: Argo CD app-of-apps config for tracing applications
 type: application
-# version and appVersion are in sync in this chart!
-version: 0.7.0
-appVersion: 0.7.0
+version: 0.7.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/tracing-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/tracing-apps/README.md
+++ b/charts/tracing-apps/README.md
@@ -1,6 +1,6 @@
 # tracing-apps
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for tracing applications
 


### PR DESCRIPTION
# Description

This gets rid of the weirdly cargoculted `appVersion` in all `*-apps` charts. It's part of my "working towards infra-apps-1.0" series of recent refactors.

Sorry for the "size" of this PR, at least the change should not lead to any visible diffs for end users.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
