### PR TITLE
chore(misc-apps): update chartmuseum to v3.6

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
-version: 0.14.2
+version: 0.15.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | chartmuseum.destination.namespace | string | `"infra-chartmuseum"` | Namespace |
 | chartmuseum.enabled | bool | `false` | Enable chartmuseum |
 | chartmuseum.repoURL | string | `"https://chartmuseum.github.io/charts"` | [repo](https://chartmuseum.github.io/charts) |
-| chartmuseum.targetRevision | string | `"3.4.*"` | [chartmuseum Helm chart](https://github.com/chartmuseum/charts/tree/main/src/chartmuseum) |
+| chartmuseum.targetRevision | string | `"3.6.*"` | [chartmuseum Helm chart](https://github.com/chartmuseum/charts/tree/main/src/chartmuseum) |
 | chartmuseum.values | object | [upstream values](https://github.com/chartmuseum/charts/blob/main/src/chartmuseum/values.yaml) | Helm values |
 | downscaler | object | - | [kube-downscaler](https://github.com/hjacobs/kube-downscaler) ([example](./examples/kube-downscaler.yaml)) |
 | downscaler.chart | string | `"kube-downscaler"` | Chart |

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -92,7 +92,7 @@ chartmuseum:
   # chartmuseum.chart -- Chart
   chart: chartmuseum
   # chartmuseum.targetRevision -- [chartmuseum Helm chart](https://github.com/chartmuseum/charts/tree/main/src/chartmuseum)
-  targetRevision: "3.4.*"
+  targetRevision: "3.6.*"
   # chartmuseum.values -- Helm values
   # @default -- [upstream values](https://github.com/chartmuseum/charts/blob/main/src/chartmuseum/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Update chartmuseum Helm chart to v3.6

# Changes

## Updates

* Chartmuseum image updated to v0.14.0: https://github.com/chartmuseum/charts/pull/33
  * Details about the v0.14.0 release can be found on the release page: https://github.com/helm/chartmuseum/releases/tag/v0.14.0
  * `--enforce-semver2` flag has been deprecated: https://github.com/helm/chartmuseum/pull/522

## Features

* Schemes can be configured for liveness and readiness checks: https://github.com/chartmuseum/charts/pull/32

# Issues

Fixes #563 

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
