### PR TITLE
feat(infra-apps): bump jaeger-operator to 2.29 (operator version 1.31)

### DIFF
--- a/charts/tracing-apps/Chart.yaml
+++ b/charts/tracing-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tracing-apps
 description: Argo CD app-of-apps config for tracing applications
 type: application
-version: 0.9.0
+version: 0.10.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/tracing-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/tracing-apps/README.md
+++ b/charts/tracing-apps/README.md
@@ -1,6 +1,6 @@
 # tracing-apps
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for tracing applications
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | jaegerOperator.destination.namespace | string | `"infra-jaeger"` | Namespace |
 | jaegerOperator.enabled | bool | `false` | Enable jaeger-operator |
 | jaegerOperator.repoURL | string | [repo](https://jaegertracing.github.io/helm-charts) | Repo URL |
-| jaegerOperator.targetRevision | string | `"2.27.*"` | [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator) |
+| jaegerOperator.targetRevision | string | `"2.29.*"` | [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator) |
 | jaegerOperator.values | object | [upstream values](https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger-operator/values.yaml) | Helm values |
 | opentelemetryCollector | object | - | [opentelemetry-collector](https://opentelemetry.io/docs/collector/) ([example](./examples/opentelemetryCollector.yaml)) |
 | opentelemetryCollector.chart | string | `"opentelemetry-collector"` | Chart |

--- a/charts/tracing-apps/values.yaml
+++ b/charts/tracing-apps/values.yaml
@@ -13,7 +13,7 @@ jaegerOperator:
   # jaegerOperator.chart -- Chart
   chart: "jaeger-operator"
   # jaegerOperator.targetRevision -- [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator)
-  targetRevision: "2.27.*"
+  targetRevision: "2.29.*"
   # jaegerOperator.values -- Helm values
   # @default -- [upstream values](https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger-operator/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Bump to jaeger-operator 1.31.0

# Issues

* https://github.com/jaegertracing/helm-charts/pull/342
  * Fix panic caused by an invalid type assertion ([#1738](https://github.com/jaegertracing/jaeger-operator/pull/1738))
  * Add ES autoprovisioning CR metric ([#1728](https://github.com/jaegertracing/jaeger-operator/pull/1728))
  * Use Elasticsearch provisioning from OpenShift Elasticsearch operator ([#1708](https://github.com/jaegertracing/jaeger-operator/pull/1708))

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
