### PR TITLE
feature(misc-apps): Add prom2teams to send alerts to Microsoft Teams

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
-version: 0.15.0
+version: 0.16.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/misc-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -44,6 +44,13 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | metallb.repoURL | string | [repo](https://metallb.github.io/metallb) | Repo URL |
 | metallb.targetRevision | string | `"0.12.*"` | [metallb Helm chart](https://github.com/metallb/metallb/tree/main/charts/metallb) |
 | metallb.values | object | [upstream values](https://github.com/metallb/metallb/blob/main/charts/metallb/values.yaml) | Helm values |
+| prom2teams | object | - | [prom2teams](https://github.com/idealista/prom2teams) ([example](./example/prom2teams.yaml)) |
+| prom2teams.chart | string | `"prom2teams"` | Chart |
+| prom2teams.destination.namespace | string | `"infra-prom2teams"` | Namespace |
+| prom2teams.enabled | bool | `false` | Enable prom2teams |
+| prom2teams.repoURL | string | `"https://prometheus-msteams.github.io/prometheus-msteams"` | [repo](https://prometheus-msteams.github.io/prometheus-msteams) |
+| prom2teams.targetRevision | string | `"3.2.*"` | [prom2teams Helm chart](https://github.com/idealista/prom2teams/tree/master/helm) |
+| prom2teams.values | object | [upstream values](https://github.com/idealista/prom2teams/blob/master/helm/values.yaml) | Helm values |
 | sentryKubernetes | object | - | [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml) |
 | sentryKubernetes.chart | string | `"sentry-kubernetes"` | Chart |
 | sentryKubernetes.destination.namespace | string | `"infra-sentry-kubernetes"` | Namespace |

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -44,13 +44,13 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | metallb.repoURL | string | [repo](https://metallb.github.io/metallb) | Repo URL |
 | metallb.targetRevision | string | `"0.12.*"` | [metallb Helm chart](https://github.com/metallb/metallb/tree/main/charts/metallb) |
 | metallb.values | object | [upstream values](https://github.com/metallb/metallb/blob/main/charts/metallb/values.yaml) | Helm values |
-| prom2teams | object | - | [prom2teams](https://github.com/idealista/prom2teams) ([example](./example/prom2teams.yaml)) |
+| prom2teams | object | - | [prom2teams](https://github.com/prometheus-msteams/prometheus-msteams) ([example](./example/prom2teams.yaml)) |
 | prom2teams.chart | string | `"prom2teams"` | Chart |
 | prom2teams.destination.namespace | string | `"infra-prom2teams"` | Namespace |
 | prom2teams.enabled | bool | `false` | Enable prom2teams |
 | prom2teams.repoURL | string | `"https://prometheus-msteams.github.io/prometheus-msteams"` | [repo](https://prometheus-msteams.github.io/prometheus-msteams) |
-| prom2teams.targetRevision | string | `"3.2.*"` | [prom2teams Helm chart](https://github.com/idealista/prom2teams/tree/master/helm) |
-| prom2teams.values | object | [upstream values](https://github.com/idealista/prom2teams/blob/master/helm/values.yaml) | Helm values |
+| prom2teams.targetRevision | string | `"1.3.*"` | [prom2teams Helm chart](https://github.com/prometheus-msteams/prometheus-msteams/tree/master/chart/prometheus-msteams) |
+| prom2teams.values | object | [upstream values](https://github.com/prometheus-msteams/prometheus-msteams/blob/master/chart/prometheus-msteams/values.yaml) | Helm values |
 | sentryKubernetes | object | - | [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml) |
 | sentryKubernetes.chart | string | `"sentry-kubernetes"` | Chart |
 | sentryKubernetes.destination.namespace | string | `"infra-sentry-kubernetes"` | Namespace |

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -44,13 +44,13 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | metallb.repoURL | string | [repo](https://metallb.github.io/metallb) | Repo URL |
 | metallb.targetRevision | string | `"0.12.*"` | [metallb Helm chart](https://github.com/metallb/metallb/tree/main/charts/metallb) |
 | metallb.values | object | [upstream values](https://github.com/metallb/metallb/blob/main/charts/metallb/values.yaml) | Helm values |
-| prom2teams | object | - | [prom2teams](https://github.com/prometheus-msteams/prometheus-msteams) ([example](./example/prom2teams.yaml)) |
-| prom2teams.chart | string | `"prom2teams"` | Chart |
-| prom2teams.destination.namespace | string | `"infra-prom2teams"` | Namespace |
-| prom2teams.enabled | bool | `false` | Enable prom2teams |
-| prom2teams.repoURL | string | `"https://prometheus-msteams.github.io/prometheus-msteams"` | [repo](https://prometheus-msteams.github.io/prometheus-msteams) |
-| prom2teams.targetRevision | string | `"1.3.*"` | [prom2teams Helm chart](https://github.com/prometheus-msteams/prometheus-msteams/tree/master/chart/prometheus-msteams) |
-| prom2teams.values | object | [upstream values](https://github.com/prometheus-msteams/prometheus-msteams/blob/master/chart/prometheus-msteams/values.yaml) | Helm values |
+| prometheusMsteams | object | - | [prometheus-msteams](https://github.com/prometheus-msteams/prometheus-msteams) ([example](./example/prometheus-msteams.yaml)) |
+| prometheusMsteams.chart | string | `"prometheus-msteams"` | Chart |
+| prometheusMsteams.destination.namespace | string | `"infra-prometheus-msteams"` | Namespace |
+| prometheusMsteams.enabled | bool | `false` | Enable prometheus-msteams |
+| prometheusMsteams.repoURL | string | `"https://prometheus-msteams.github.io/prometheus-msteams"` | [repo](https://prometheus-msteams.github.io/prometheus-msteams) |
+| prometheusMsteams.targetRevision | string | `"1.3.*"` | [prometheus-msteams Helm chart](https://github.com/prometheus-msteams/prometheus-msteams/tree/master/chart/prometheus-msteams) |
+| prometheusMsteams.values | object | [upstream values](https://github.com/prometheus-msteams/prometheus-msteams/blob/master/chart/prometheus-msteams/values.yaml) | Helm values |
 | sentryKubernetes | object | - | [sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) ([example](./examples/sentry-kubernetes.yaml) |
 | sentryKubernetes.chart | string | `"sentry-kubernetes"` | Chart |
 | sentryKubernetes.destination.namespace | string | `"infra-sentry-kubernetes"` | Namespace |

--- a/charts/misc-apps/examples/prom2teams.yaml
+++ b/charts/misc-apps/examples/prom2teams.yaml
@@ -1,0 +1,20 @@
+prom2teams:
+  enabled: true
+  project: infra-prom2teams
+  values:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 200Mi
+    prom2teams:
+      host: 0.0.0.0
+      port: 8089
+      connector:
+      connectors: {}
+      # group_alerts_by can be one of
+      # ("name" | "description" | "instance" | "severity" | "status" | "summary" | "fingerprint" | "runbook_url")
+      group_alerts_by:
+      # loglevel can be one of (DEBUG | INFO | WARNING | ERROR | CRITICAL)
+      loglevel: INFO
+      templatepath: /opt/prom2teams/helmconfig/teams.j2
+      config: /opt/prom2teams/helmconfig/config.ini

--- a/charts/misc-apps/examples/prom2teams.yaml
+++ b/charts/misc-apps/examples/prom2teams.yaml
@@ -6,15 +6,13 @@ prom2teams:
       limits:
         cpu: 100m
         memory: 200Mi
-    prom2teams:
-      host: 0.0.0.0
-      port: 8089
-      connector:
-      connectors: {}
-      # group_alerts_by can be one of
-      # ("name" | "description" | "instance" | "severity" | "status" | "summary" | "fingerprint" | "runbook_url")
-      group_alerts_by:
-      # loglevel can be one of (DEBUG | INFO | WARNING | ERROR | CRITICAL)
-      loglevel: INFO
-      templatepath: /opt/prom2teams/helmconfig/teams.j2
-      config: /opt/prom2teams/helmconfig/config.ini
+
+    connectors:
+    # in alertmanager, this will be used as http://prometheus-msteams:2000/bar
+    - bar: https://outlook.office.com/webhook/xxxx/xxxx
+    # in alertmanager, this will be used as http://prometheus-msteams:2000/foo
+    - foo: https://outlook.office.com/webhook/xxxx/xxxx
+
+    metrics:
+      serviceMonitor:
+        enabled: true

--- a/charts/misc-apps/examples/prometheus-msteams.yaml
+++ b/charts/misc-apps/examples/prometheus-msteams.yaml
@@ -1,6 +1,6 @@
-prom2teams:
+prometheusMsteams:
   enabled: true
-  project: infra-prom2teams
+  project: infra-prometheus-msteams
   values:
     resources:
       limits:

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -96,3 +96,22 @@ chartmuseum:
   # chartmuseum.values -- Helm values
   # @default -- [upstream values](https://github.com/chartmuseum/charts/blob/main/src/chartmuseum/values.yaml)
   values: {}
+
+# prom2teams -- [prom2teams](https://github.com/idealista/prom2teams) ([example](./example/prom2teams.yaml))
+# @default -- -
+prom2teams:
+  # prom2teams.enabled -- Enable prom2teams
+  enabled: false
+  name: prom2teams
+  destination:
+    # prom2teams.destination.namespace -- Namespace
+    namespace: "infra-prom2teams"
+  # prom2teams.repoURL -- [repo](https://prometheus-msteams.github.io/prometheus-msteams)
+  repoURL: https://prometheus-msteams.github.io/prometheus-msteams
+  # prom2teams.chart -- Chart
+  chart: prom2teams
+  # prom2teams.targetRevision -- [prom2teams Helm chart](https://github.com/idealista/prom2teams/tree/master/helm)
+  targetRevision: "3.2.*"
+  # prom2teams.values -- Helm values
+  # @default -- [upstream values](https://github.com/idealista/prom2teams/blob/master/helm/values.yaml)
+  values: {}

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -97,21 +97,21 @@ chartmuseum:
   # @default -- [upstream values](https://github.com/chartmuseum/charts/blob/main/src/chartmuseum/values.yaml)
   values: {}
 
-# prom2teams -- [prom2teams](https://github.com/prometheus-msteams/prometheus-msteams) ([example](./example/prom2teams.yaml))
+# prometheusMsteams -- [prometheus-msteams](https://github.com/prometheus-msteams/prometheus-msteams) ([example](./example/prometheus-msteams.yaml))
 # @default -- -
-prom2teams:
-  # prom2teams.enabled -- Enable prom2teams
+prometheusMsteams:
+  # prometheusMsteams.enabled -- Enable prometheus-msteams
   enabled: false
-  name: prom2teams
+  name: prometheus-msteams
   destination:
-    # prom2teams.destination.namespace -- Namespace
-    namespace: "infra-prom2teams"
-  # prom2teams.repoURL -- [repo](https://prometheus-msteams.github.io/prometheus-msteams)
+    # prometheusMsteams.destination.namespace -- Namespace
+    namespace: "infra-prometheus-msteams"
+  # prometheusMsteams.repoURL -- [repo](https://prometheus-msteams.github.io/prometheus-msteams)
   repoURL: https://prometheus-msteams.github.io/prometheus-msteams
-  # prom2teams.chart -- Chart
-  chart: prom2teams
-  # prom2teams.targetRevision -- [prom2teams Helm chart](https://github.com/prometheus-msteams/prometheus-msteams/tree/master/chart/prometheus-msteams)
+  # prometheusMsteams.chart -- Chart
+  chart: prometheus-msteams
+  # prometheusMsteams.targetRevision -- [prometheus-msteams Helm chart](https://github.com/prometheus-msteams/prometheus-msteams/tree/master/chart/prometheus-msteams)
   targetRevision: "1.3.*"
-  # prom2teams.values -- Helm values
+  # prometheusMsteams.values -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-msteams/prometheus-msteams/blob/master/chart/prometheus-msteams/values.yaml)
   values: {}

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -97,7 +97,7 @@ chartmuseum:
   # @default -- [upstream values](https://github.com/chartmuseum/charts/blob/main/src/chartmuseum/values.yaml)
   values: {}
 
-# prom2teams -- [prom2teams](https://github.com/idealista/prom2teams) ([example](./example/prom2teams.yaml))
+# prom2teams -- [prom2teams](https://github.com/prometheus-msteams/prometheus-msteams) ([example](./example/prom2teams.yaml))
 # @default -- -
 prom2teams:
   # prom2teams.enabled -- Enable prom2teams
@@ -110,8 +110,8 @@ prom2teams:
   repoURL: https://prometheus-msteams.github.io/prometheus-msteams
   # prom2teams.chart -- Chart
   chart: prom2teams
-  # prom2teams.targetRevision -- [prom2teams Helm chart](https://github.com/idealista/prom2teams/tree/master/helm)
-  targetRevision: "3.2.*"
+  # prom2teams.targetRevision -- [prom2teams Helm chart](https://github.com/prometheus-msteams/prometheus-msteams/tree/master/chart/prometheus-msteams)
+  targetRevision: "1.3.*"
   # prom2teams.values -- Helm values
-  # @default -- [upstream values](https://github.com/idealista/prom2teams/blob/master/helm/values.yaml)
+  # @default -- [upstream values](https://github.com/prometheus-msteams/prometheus-msteams/blob/master/chart/prometheus-msteams/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Add chart for prom2teams to forward Prometheus Alerts to Microsoft Teams using defined connectors 

# Checklist

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalize
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
