### PR TITLE
docs: make wording in pr template more clear

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,10 +21,10 @@
     be prepared to add more items.
 -->
 
+* [ ] This PR contains a description of the changes I'm making
 * [ ] I updated the version in Chart.yaml
 * [ ] I updated applicable README.md files using  `pre-commit run`
 * [ ] I documented any high-level concepts I'm introducing in `docs/`
-* [ ] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
 * [ ] CI is currently green and this is ready for review
 * [ ] I am ready to test changes after they are applied and released
 


### PR DESCRIPTION
# Description

This makes the PR template's wording about adding a description less ambiguous.

# Issues

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] If I updated a dependency tool, or app, this PR contains a short summary of the changes I'm pulling
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
