### PR TITLE
fix(barman): Adjust slot-creation

### DIFF
--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: barman
 type: application
 description: Chart for Barman PostgreSQL Backup and Recovery Manager
-version: 0.7.0
+version: 0.7.1
 appVersion: "v2.19"
 keywords:
   - barman

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -46,6 +46,8 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | barman.retentionPolicy | string | `"RECOVERY WINDOW of 1 MONTH"` | Barman retention policy |
 | deployment.additionalVolumeMounts | list | `[]` | Specify additional VolumeMounts for the barman container |
 | deployment.additionalVolumes | list | `[]` | Specify additional Volumes for the deployment |
+| deployment.annotations | object | `{}` | Specify deployment annotations |
+| deployment.podAnnotations | object | `{}` | Specify pod annotations |
 | deployment.strategy.type | string | `"RollingUpdate"` | Specify the strategy used to replace old Pods by new ones |
 | image.pullPolicy | string | `"Always"` | When to pull the container image |
 | image.repository | string | `"ubcctlt/barman"` | Container image to deploy |

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -1,6 +1,6 @@
 # barman
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.19](https://img.shields.io/badge/AppVersion-v2.19-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.19](https://img.shields.io/badge/AppVersion-v2.19-informational?style=flat-square)
 
 Chart for Barman PostgreSQL Backup and Recovery Manager
 
@@ -23,9 +23,10 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | barman.backupMethod | string | `"postgres"` | Barman backup method |
 | barman.backupOptions | string | `"concurrent_backup"` | Barman backup options |
 | barman.backupSchedule | string | `"0 4 * * *"` | Barman backup schedule |
-| barman.backups[0] | object | `{"additionalConfiguration":"","backupMethod":"postgres","databaseSlotName":"barman","lastBackupMaximumAge":"1 day","namespace":"postgresql","postgresql":{"host":"postgresql","port":5432,"replicationPassword":"barman","replicationUser":"barman","superUser":"postgres","superUserDatabase":"postgres","superUserPassword":"postgres"},"retentionPolicy":"RECOVERY WINDOW of 1 MONTH","serviceaccount":"postgresql"}` | Barman retention policy |
+| barman.backups[0] | object | `{"additionalConfiguration":"","backupMethod":"postgres","createDatabaseSlot":true,"databaseSlotName":"barman","lastBackupMaximumAge":"1 day","namespace":"postgresql","postgresql":{"host":"postgresql","port":5432,"replicationPassword":"barman","replicationUser":"barman","superUser":"postgres","superUserDatabase":"postgres","superUserPassword":"postgres"},"retentionPolicy":"RECOVERY WINDOW of 1 MONTH","serviceaccount":"postgresql"}` | Barman retention policy |
 | barman.backups[0].additionalConfiguration | string | `""` | Barman additional Parameters for configuration File |
 | barman.backups[0].backupMethod | string | `"postgres"` | Barman backup method |
+| barman.backups[0].createDatabaseSlot | bool | `true` | Create Database slot |
 | barman.backups[0].databaseSlotName | string | `"barman"` | Database slot name to be created/used |
 | barman.backups[0].lastBackupMaximumAge | string | `"1 day"` | Barman last backup maximum age |
 | barman.backups[0].namespace | string | `"postgresql"` | namespace where postgresql is deployed |
@@ -39,6 +40,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | barman.backups[0].serviceaccount | string | `"postgresql"` | service account of the postgresql deployment |
 | barman.barmanUser | string | `"barman"` | Barman user |
 | barman.compression | string | `"gzip"` | Barman backup compression |
+| barman.createDatabaseSlot | bool | `true` | Create Database slot |
 | barman.databaseSlotName | string | `"barman"` | Database slot name to be created/used |
 | barman.lastBackupMaximumAge | string | `"1 day"` | Barman last backup maximum age |
 | barman.retentionPolicy | string | `"RECOVERY WINDOW of 1 MONTH"` | Barman retention policy |

--- a/charts/barman/templates/configmap-barman-cron.yaml
+++ b/charts/barman/templates/configmap-barman-cron.yaml
@@ -6,8 +6,10 @@ metadata:
     {{- include "barman.labels" . | nindent 4 }}
 data:
   barman: |
-      * * * * * barman /usr/local/bin/barman receive-wal --create-slot pg; /usr/local/bin/barman cron
       {{- range .Values.barman.backups }}
+      {{- if .createDatabaseSlot }}
+      * * * * * barman /usr/local/bin/barman receive-wal --create-slot {{ .postgresql.host }}; /usr/local/bin/barman cron
+      {{- end }}
       {{- if hasKey . "backupSchedule" }}
       {{ .backupSchedule }} barman /usr/local/bin/barman backup {{ .postgresql.host }}
       {{- else }}

--- a/charts/barman/templates/configmap-barman-cron.yaml
+++ b/charts/barman/templates/configmap-barman-cron.yaml
@@ -7,8 +7,14 @@ metadata:
 data:
   barman: |
       {{- range .Values.barman.backups }}
+      {{- if hasKey . "createDatabaseSlot" }}
       {{- if .createDatabaseSlot }}
       * * * * * barman /usr/local/bin/barman receive-wal --create-slot {{ .postgresql.host }}; /usr/local/bin/barman cron
+      {{- end }}
+      {{- else }}
+      {{- if $.Values.barman.createDatabaseSlot }}
+      * * * * * barman /usr/local/bin/barman receive-wal --create-slot {{ .postgresql.host }}; /usr/local/bin/barman cron
+      {{- end }}
       {{- end }}
       {{- if hasKey . "backupSchedule" }}
       {{ .backupSchedule }} barman /usr/local/bin/barman backup {{ .postgresql.host }}

--- a/charts/barman/templates/deployment.yaml
+++ b/charts/barman/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "barman.fullname" . }}
   labels:
     {{- include "barman.labels" . | nindent 4 }}
+  {{- with .Values.deployment.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -13,6 +16,9 @@ spec:
     type: {{ .Values.deployment.strategy.type | quote }}
   template:
     metadata:
+      {{- with .Values.deployment.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "barman.labels" . | nindent 8 }}
     spec:

--- a/charts/barman/values.yaml
+++ b/charts/barman/values.yaml
@@ -70,6 +70,8 @@ barman:
   backupSchedule: "0 4 * * *"
   # -- Database slot name to be created/used
   databaseSlotName: barman
+  # -- Create Database slot
+  createDatabaseSlot: true
 
   backups:
       # -- Barman retention policy
@@ -78,6 +80,8 @@ barman:
       backupMethod: postgres
       # -- Database slot name to be created/used
       databaseSlotName: barman
+      # -- Create Database slot
+      createDatabaseSlot: true
       # -- Barman last backup maximum age
       lastBackupMaximumAge: "1 day"
       # -- Barman additional Parameters for configuration File

--- a/charts/barman/values.yaml
+++ b/charts/barman/values.yaml
@@ -22,6 +22,10 @@ deployment:
   additionalVolumeMounts: []
   # -- Specify additional Volumes for the deployment
   additionalVolumes: []
+  # -- Specify deployment annotations
+  annotations: {}
+  # -- Specify pod annotations
+  podAnnotations: {}
 
 persistence:
   data:


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Hello, creating a slot failed on our side because `ERROR: Unknown server 'pg'`.
I found it hardcoded in the cronjob. 
Wouldn't it be better to use the `postgres.host` value for creating the db slot?
Let me know what you think!

Best

# Issues

````bash
barman.server ERROR: Check 'replication slot' failed for server 'xxxxxxx'
	replication slot: FAILED (replication slot 'barman' doesn't exist. Please execute 'barman receive-wal --create-slot xxxxxxx')
	directories: OK
	retention policy settings: OK
````


# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [ ] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
