### PR TITLE
chore(huawei-csi-plugin): annotate image to disable security scanning

### DIFF
--- a/charts/huawei-csi-plugin/.helmignore
+++ b/charts/huawei-csi-plugin/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/huawei-csi-plugin/Chart.yaml
+++ b/charts/huawei-csi-plugin/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+appVersion: v2.2.15
+deprecated: true
+description: ⚠️ (OBSOLETE) request for upstream chart is https://github.com/Huawei/eSDK_K8S_Plugin/issues/16
+home: https://github.com/Huawei/eSDK_K8S_Plugin
+name: huawei-csi-plugin
+sources:
+- https://github.com/Huawei/eSDK_K8S_Plugin
+- https://github.com/adfinis-sygroup/huawei-csi-plugin
+- https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/huawei-csi-plugin
+type: application
+version: 0.3.3
+annotations:
+  artifacthub.io/images: |
+    - name: csi-attacher
+      repo: quay.io/k8scsi/csi-attacher:v1.2.1
+      whitelisted: true

--- a/charts/huawei-csi-plugin/README.md
+++ b/charts/huawei-csi-plugin/README.md
@@ -1,0 +1,84 @@
+# huawei-csi-plugin
+
+> **:exclamation: This Helm Chart is deprecated!**
+
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.15](https://img.shields.io/badge/AppVersion-v2.2.15-informational?style=flat-square)
+
+⚠️ (OBSOLETE) request for upstream chart is https://github.com/Huawei/eSDK_K8S_Plugin/issues/16
+
+**Homepage:** <https://github.com/Huawei/eSDK_K8S_Plugin>
+
+## Source Code
+
+* <https://github.com/Huawei/eSDK_K8S_Plugin>
+* <https://github.com/adfinis-sygroup/huawei-csi-plugin>
+* <https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/huawei-csi-plugin>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller | object | `{'replicaCount':1}` | different configuration options of controller deployment |
+| csi_attacher.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-attacher |
+| csi_attacher.image.repository | string | `"quay.io/k8scsi/csi-attacher"` | Image Repo for csi-attacher |
+| csi_attacher.image.tag | string | `"v1.2.1"` | Image Tag for csi-attacher |
+| csi_attacher.resources | object | `{}` | resources for csi-attacher |
+| csi_driver.controller.resources | object | `{}` | resources for csi-driver container within controller-deployment |
+| csi_driver.controller.securityContext | object | - | securityContext for the huawei-csi-driver container in the controller deployment |
+| csi_driver.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-driver |
+| csi_driver.image.repository | string | `"ghcr.io/adfinis-sygroup/huawei-csi-plugin"` | Image Repo for csi-driver |
+| csi_driver.image.tag | string | `"v2.2.14"` | Image Tag for csi-driver |
+| csi_driver.node.resources | object | `{}` | resources for csi-driver container within node-daemonset |
+| csi_driver.node.securityContext | object | - | securityContext esacalates all the privileges for csi-driver container within node-daemonset |
+| csi_livenessprobe.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for livenessprobe |
+| csi_livenessprobe.image.repository | string | `"k8s.gcr.io/sig-storage/livenessprobe"` | Image Repo for livenessprobe |
+| csi_livenessprobe.image.tag | string | `"v2.4.0"` | Image Tag for livenessprobe |
+| csi_livenessprobe.resources | object | `{}` | resources for livenessprobe |
+| csi_node_driver_registrar.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-node-driver-registrar |
+| csi_node_driver_registrar.image.repository | string | `"quay.io/k8scsi/csi-node-driver-registrar"` | Image Repo for csi-node-driver-registrar |
+| csi_node_driver_registrar.image.tag | string | `"v2.0.1"` | Image Tag for csi-node-driver-registrar |
+| csi_node_driver_registrar.resources | object | `{}` | resources for csi-node-driver-registrar |
+| csi_provisioner.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-provisioner |
+| csi_provisioner.image.repository | string | `"quay.io/k8scsi/csi-provisioner"` | Image Repo for csi-provisioner |
+| csi_provisioner.image.tag | string | `"v1.6.0"` | Image Tag for csi-provisioner |
+| csi_provisioner.resources | object | `{}` | resources for csi-provisioner |
+| csi_resizer.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-resizer |
+| csi_resizer.image.repository | string | `"quay.io/k8scsi/csi-resizer"` | Image Repo for csi-resizer |
+| csi_resizer.image.tag | string | `"v1.0.1"` | Image Tag for csi-resizer |
+| csi_resizer.resources | object | `{}` | resources for csi-resizer |
+| csi_snapshot_controller.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-snapshot-controller |
+| csi_snapshot_controller.image.repository | string | `"quay.io/k8scsi/snapshot-controller"` | Image Repo for csi-snapshot-controller |
+| csi_snapshot_controller.image.tag | string | `"v3.0.2"` | Image Tag for csi-snapshot-controller |
+| csi_snapshot_controller.resources | object | `{}` | resources for csi-snapshot-controller |
+| csi_snapshotter.image.pullPolicy | string | `"IfNotPresent"` | Image PullPolicy for csi-snapshotter |
+| csi_snapshotter.image.repository | string | `"quay.io/k8scsi/csi-snapshotter"` | Image Repo for csi-snapshotter |
+| csi_snapshotter.image.tag | string | `"v3.0.2"` | Image Tag for csi-snapshotter |
+| csi_snapshotter.resources | object | `{}` | resources for csi-snapshotter |
+| csiconfig | object | `{'backends': []}` | backend configuration for the csi controller (see [documentation](https://github.com/Huawei/eSDK_K8S_Plugin/tree/master/docs/en)) |
+| features.multiController.enabled | bool | `false` | specifies if multiController is enabled or not |
+| features.resizing.enabled | bool | `true` | specifies if resizing is enabled or not |
+| features.snapshotting.enabled | bool | `true` | specifies if snapshotting is enabled or not |
+| fullnameOverride | string | `""` | specifies the full name override to be used for helm |
+| imagePullSecrets | list | `[]` | specifies the image pull secrets to be used |
+| nameOverride | string | `""` | specifies the name override to be used for helm |
+| node | object | - | different configuration options of node daemonset |
+| rbac.create | bool | `true` | Whether to create RBAC or not |
+| serviceAccount.annotations | object | `{}` | annotations to add to each service account |
+| serviceAccount.create | bool | `true` | Whether to create serviceAccounts or not |
+
+## About this chart
+
+Adfinis fights for a software world that is more open, where the quality is
+better and where software must be accessible to everyone. This chart
+is part of the action behind this commitment. Feel free to
+[contact](https://adfinis.com/kontakt/?pk_campaign=github&pk_kwd=helm-charts)
+us if you have any questions.
+
+## License
+
+This Helm chart is free software: you can redistribute it and/or modify it under the terms
+of the GNU Affero General Public License as published by the Free Software Foundation,
+version 3 of the License.
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs/)

--- a/charts/huawei-csi-plugin/ci/defaults-values.yaml
+++ b/charts/huawei-csi-plugin/ci/defaults-values.yaml
@@ -1,0 +1,8 @@
+# The CRD defintions provided by Huawei are using the
+# apiextensions.k8s.io/v1beta1 which is deprecated so
+# our CI tests are failing. But just changing the api-
+# Version to apiextensions.k8s.io/v1 will break the
+# CRD creation
+features:
+  snapshotting:
+    enabled: false

--- a/charts/huawei-csi-plugin/docs/INSTALL.md
+++ b/charts/huawei-csi-plugin/docs/INSTALL.md
@@ -1,0 +1,20 @@
+# Installation of the huawei-csi-plugin
+
+## Helm installation
+
+Because of the way the Huawei CSI plugin is currently designed it must be
+installed in the `kube-system` namespace and with `fullnameOverride` set to
+`huawei-csi`.
+
+```
+helm install --namespace kube-system huawei-csi adfinis/huawei-csi-plugin --set fullnameOverride=huawei-csi
+```
+
+## Generate secret
+
+To generate the secret `huawei-csi-secret` after the Helm installation has been
+finished you need to grab the `secretGenerate` binary from the respective ZIP
+archive of your Huawei eSDK release
+(<https://github.com/Huawei/eSDK_K8S_Plugin/releases>) and execute it. You have
+to input the credentials for every configured backend and it will generate the
+secret for you.

--- a/charts/huawei-csi-plugin/templates/_helpers.tpl
+++ b/charts/huawei-csi-plugin/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "huawei-csi-plugin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "huawei-csi-plugin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "huawei-csi-plugin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "huawei-csi-plugin.labels" -}}
+helm.sh/chart: {{ include "huawei-csi-plugin.chart" . }}
+{{ include "huawei-csi-plugin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "huawei-csi-plugin.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "huawei-csi-plugin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "huawei-csi-plugin.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "huawei-csi-plugin.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/huawei-csi-plugin/templates/configmap.yaml
+++ b/charts/huawei-csi-plugin/templates/configmap.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-configmap
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+data:
+  csi.json: |
+    {{ .Values.csiconfig | mustToJson }}

--- a/charts/huawei-csi-plugin/templates/daemonset-node.yaml
+++ b/charts/huawei-csi-plugin/templates/daemonset-node.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-node
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "huawei-csi-node"
+spec:
+  selector:
+    matchLabels:
+      {{- include "huawei-csi-plugin.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "csi-node"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.node.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "huawei-csi-plugin.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "csi-node"
+    spec:
+      serviceAccountName: {{ include "huawei-csi-plugin.fullname" . }}-node
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml | nindent 8 }}
+      {{- end }}
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: liveness-probe
+          image: "{{ .Values.csi_livenessprobe.image.repository }}:{{ .Values.csi_livenessprobe.image.tag }}"
+          args:
+          - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+          - --health-port=9800
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+          - mountPath: /var/lib/csi/sockets/pluginproxy/
+            name: plugin-dir
+
+        - name: csi-node-driver-registrar
+          image: "{{ .Values.csi_node_driver_registrar.image.repository }}:{{ .Values.csi_node_driver_registrar.image.tag }}"
+          imagePullPolicy: {{ .Values.csi_node_driver_registrar.image.pullPolicy }}
+          args:
+            - "--csi-address=/csi/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/csi.huawei.com/csi.sock"
+          resources:
+            {{- toYaml .Values.csi_node_driver_registrar.resources | nindent 12 }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+
+        - name: huawei-csi-driver
+          image: "{{ .Values.csi_driver.image.repository }}:{{ .Values.csi_driver.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.csi_driver.image.pullPolicy }}
+          args:
+            - "--endpoint=/csi/csi.sock"
+            - "--containerized"
+            - "--driver-name=csi.huawei.com"
+            - "--volume-use-multipath=true"
+            - "--loggingModule=console"
+          env:
+            - name: CSI_NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          resources:
+            {{- toYaml .Values.csi_driver.node.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.csi_driver.node.securityContext | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -f /csi/csi.sock"]
+          ports:
+            - containerPort: 9800
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 60
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: etc-dir
+              mountPath: /etc
+            - name: dev-dir
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
+            - name: iscsi-dir
+              mountPath: /var/lib/iscsi
+            - name: config-map
+              mountPath: /etc/huawei
+            - name: secret
+              mountPath: /etc/huawei/secret
+
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.huawei.com
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: pods-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: etc-dir
+          hostPath:
+            path: /etc
+            type: Directory
+        - name: dev-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: iscsi-dir
+          hostPath:
+            path: /var/lib/iscsi
+            type: Directory
+        - name: config-map
+          configMap:
+            name: {{ include "huawei-csi-plugin.fullname" . }}-configmap
+        - name: secret
+          secret:
+            secretName: huawei-csi-secret
+
+      {{- with .Values.node.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/huawei-csi-plugin/templates/deployment-controller.yaml
+++ b/charts/huawei-csi-plugin/templates/deployment-controller.yaml
@@ -1,0 +1,177 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "huawei-csi-controller"
+spec:
+  {{- if .Values.features.multiController.enabled }}
+  replicas: {{ .Values.controller.replicaCount }}
+  {{- else }}
+  replicas: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "huawei-csi-plugin.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "csi-controller"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "huawei-csi-plugin.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "csi-controller"
+    spec:
+      serviceAccount: {{ include "huawei-csi-plugin.fullname" . }}-controller
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      hostNetwork: true
+      containers:
+        - name: liveness-probe
+          image: "{{ .Values.csi_livenessprobe.image.repository }}:{{ .Values.csi_livenessprobe.image.tag }}"
+          args:
+          - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+          - --health-port=9808
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+          - mountPath: /var/lib/csi/sockets/pluginproxy/
+            name: socket-dir
+
+        - name: csi-provisioner
+          image: "{{ .Values.csi_provisioner.image.repository }}:{{ .Values.csi_provisioner.image.tag }}"
+          imagePullPolicy: {{ .Values.csi_provisioner.image.pullPolicy }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=6h"
+            - "--feature-gates=Topology=true"
+            {{- if .Values.features.multiController.enabled }}
+            - "--enable-leader-election"
+            {{- end }}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+
+        - name: csi-attacher
+          image: "{{ .Values.csi_attacher.image.repository }}:{{ .Values.csi_attacher.image.tag }}"
+          imagePullPolicy: {{ .Values.csi_attacher.image.pullPolicy }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            {{- if .Values.features.multiController.enabled }}
+            - "--leader-election"
+            - "--leader-election-type=leases"
+            {{- end }}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+
+        {{- if .Values.features.resizing.enabled }}
+        - name: csi-resizer
+          image: "{{ .Values.csi_resizer.image.repository }}:{{ .Values.csi_resizer.image.tag }}"
+          imagePullPolicy: {{ .Values.csi_resizer.image.pullPolicy }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        {{- end }}
+
+        {{- if .Values.features.snapshotting.enabled }}
+        - name: csi-snapshotter
+          image: "{{ .Values.csi_snapshotter.image.repository }}:{{ .Values.csi_snapshotter.image.tag }}"
+          imagePullPolicy: {{ .Values.csi_snapshotter.image.pullPolicy }}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+
+        - name: snapshot-controller
+          image: "{{ .Values.csi_snapshot_controller.image.repository }}:{{ .Values.csi_snapshot_controller.image.tag }}"
+          imagePullPolicy: {{ .Values.csi_snapshot_controller.image.pullPolicy }}
+          args:
+            - "--v=5"
+            - "--leader-election=false"
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+        {{- end }}
+
+        - name: huawei-csi-driver
+          image: "{{ .Values.csi_driver.image.repository }}:{{ .Values.csi_driver.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.csi_driver.image.pullPolicy }}
+          args:
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--controller"
+            - "--containerized"
+            - "--driver-name=csi.huawei.com"
+            - "--loggingModule=console"
+            {{- if .Values.features.resizing.enabled }}
+            - "--backend-update-interval=120"
+            {{- end }}
+          env:
+            - name: CSI_ENDPOINT
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 60
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: config-map
+              mountPath: /etc/huawei
+            - name: secret
+              mountPath: /etc/huawei/secret
+          securityContext:
+            {{- toYaml .Values.controller.securityContext | nindent 12 }}
+
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: config-map
+          configMap:
+            name: {{ include "huawei-csi-plugin.fullname" . }}-configmap
+        - name: secret
+          secret:
+            secretName: huawei-csi-secret
+
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/huawei-csi-plugin/templates/rbac.yaml
+++ b/charts/huawei-csi-plugin/templates/rbac.yaml
@@ -1,0 +1,356 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-provisioner-runner
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    {{- if .Values.features.resizing.enabled }}
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+    {{- else }}
+    verbs: ["get", "list", "watch", "create", "delete"]
+    {{- end }}
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    {{- if .Values.features.resizing.enabled }}
+    verbs: ["get", "list", "watch", "update", "patch"]
+    {{- else }}
+    verbs: ["get", "list", "watch", "update"]
+    {{- end }}
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    {{- if .Values.features.snapshotting.enabled }}
+    verbs: ["list", "watch", "create", "update", "patch"]
+    {{- else }}
+    verbs: ["get", "list"]
+    {{- end }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    {{- if .Values.features.snapshotting.enabled }}
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+    {{- else }}
+    verbs: ["get", "list"]
+    {{- end }}
+  {{- if .Values.features.snapshotting.enabled }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  {{- end }}
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-provisioner-role
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "huawei-csi-plugin.fullname" . }}-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-attacher-runner
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-attacher-role
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "huawei-csi-plugin.fullname" . }}-attacher-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-driver-registrar-runner
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-driver-registrar-role
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-node
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "huawei-csi-plugin.fullname" . }}-driver-registrar-runner
+  apiGroup: rbac.authorization.k8s.io
+
+{{- if .Values.features.resizing.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-resizer-runner
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-resizer-role
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "huawei-csi-plugin.fullname" . }}-resizer-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-resizer-cfg
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-resizer-role-cfg
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "huawei-csi-plugin.fullname" . }}-resizer-cfg
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+
+{{- if .Values.features.snapshotting.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshotter-runner
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshotter-role
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshotter-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshotter-leaderelection
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshotter-leaderelection
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshotter-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshot-controller-runner
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshot-controller-role
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshot-controller-leaderelection
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshot-controller-leaderelection
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "huawei-csi-plugin.fullname" . }}-snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+
+---
+{{- end }}
+
+{{- end }}

--- a/charts/huawei-csi-plugin/templates/serviceaccount.yaml
+++ b/charts/huawei-csi-plugin/templates/serviceaccount.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-controller
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "huawei-csi-plugin.fullname" . }}-node
+  labels:
+    {{- include "huawei-csi-plugin.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+{{- end }}

--- a/charts/huawei-csi-plugin/values.yaml
+++ b/charts/huawei-csi-plugin/values.yaml
@@ -1,0 +1,178 @@
+csi_attacher:
+  image:
+    # csi_attacher.image.repository -- Image Repo for csi-attacher
+    repository: "quay.io/k8scsi/csi-attacher"
+    # csi_attacher.image.tag -- Image Tag for csi-attacher
+    tag: "v1.2.1"
+    # csi_attacher.image.pullPolicy -- Image PullPolicy for csi-attacher
+    pullPolicy: IfNotPresent
+  # csi_attacher.resources -- resources for csi-attacher
+  resources: {}
+csi_driver:
+  image:
+    # csi_driver.image.repository -- Image Repo for csi-driver
+    repository: "ghcr.io/adfinis-sygroup/huawei-csi-plugin"
+    # csi_driver.image.tag -- Image Tag for csi-driver
+    tag: "v2.2.14"
+    # csi_driver.image.pullPolicy -- Image PullPolicy for csi-driver
+    pullPolicy: IfNotPresent
+  controller:
+    # csi_driver.controller.securityContext -- securityContext for the huawei-csi-driver container in the controller deployment
+    # @default -- -
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+    # csi_driver.controller.resources -- resources for csi-driver container within controller-deployment
+    resources: {}
+  node:
+    # csi_driver.node.securityContext -- securityContext esacalates all the privileges for csi-driver container within node-daemonset
+    # @default -- -
+    securityContext:
+      privileged: true
+      capabilities:
+        add:
+        - "SYS_ADMIN"
+      allowPrivilegeEscalation: true
+      runAsUser: 0
+    # csi_driver.node.resources -- resources for csi-driver container within node-daemonset
+    resources: {}
+csi_livenessprobe:
+  image:
+    # csi_livenessprobe.image.repository -- Image Repo for livenessprobe
+    repository: "k8s.gcr.io/sig-storage/livenessprobe"
+    # csi_livenessprobe.image.tag -- Image Tag for livenessprobe
+    tag: "v2.4.0"
+    # csi_livenessprobe.image.pullPolicy -- Image PullPolicy for livenessprobe
+    pullPolicy: IfNotPresent
+  # csi_livenessprobe.resources -- resources for livenessprobe
+  resources: {}
+csi_node_driver_registrar:
+  image:
+    # csi_node_driver_registrar.image.repository -- Image Repo for csi-node-driver-registrar
+    repository: "quay.io/k8scsi/csi-node-driver-registrar"
+    # csi_node_driver_registrar.image.tag -- Image Tag for csi-node-driver-registrar
+    tag: "v2.0.1"
+    # csi_node_driver_registrar.image.pullPolicy -- Image PullPolicy for csi-node-driver-registrar
+    pullPolicy: IfNotPresent
+  # csi_node_driver_registrar.resources -- resources for csi-node-driver-registrar
+  resources: {}
+csi_provisioner:
+  image:
+    # csi_provisioner.image.repository -- Image Repo for csi-provisioner
+    repository: "quay.io/k8scsi/csi-provisioner"
+    # csi_provisioner.image.tag -- Image Tag for csi-provisioner
+    tag: "v1.6.0"
+    # csi_provisioner.image.pullPolicy -- Image PullPolicy for csi-provisioner
+    pullPolicy: IfNotPresent
+  # csi_provisioner.resources -- resources for csi-provisioner
+  resources: {}
+csi_resizer:
+  image:
+    # csi_resizer.image.repository -- Image Repo for csi-resizer
+    repository: "quay.io/k8scsi/csi-resizer"
+    # csi_resizer.image.tag -- Image Tag for csi-resizer
+    tag: "v1.0.1"
+    # csi_resizer.image.pullPolicy -- Image PullPolicy for csi-resizer
+    pullPolicy: IfNotPresent
+  # csi_resizer.resources -- resources for csi-resizer
+  resources: {}
+csi_snapshot_controller:
+  image:
+    # csi_snapshot_controller.image.repository -- Image Repo for csi-snapshot-controller
+    repository: "quay.io/k8scsi/snapshot-controller"
+    # csi_snapshot_controller.image.tag -- Image Tag for csi-snapshot-controller
+    tag: "v3.0.2"
+    # csi_snapshot_controller.image.pullPolicy -- Image PullPolicy for csi-snapshot-controller
+    pullPolicy: IfNotPresent
+  # csi_snapshot_controller.resources -- resources for csi-snapshot-controller
+  resources: {}
+csi_snapshotter:
+  image:
+    # csi_snapshotter.image.repository -- Image Repo for csi-snapshotter
+    repository: "quay.io/k8scsi/csi-snapshotter"
+    # csi_snapshotter.image.tag -- Image Tag for csi-snapshotter
+    tag: "v3.0.2"
+    # csi_snapshotter.image.pullPolicy -- Image PullPolicy for csi-snapshotter
+    pullPolicy: IfNotPresent
+  # csi_snapshotter.resources -- resources for csi-snapshotter
+  resources: {}
+
+# imagePullSecrets -- specifies the image pull secrets to be used
+imagePullSecrets: []
+# nameOverride -- specifies the name override to be used for helm
+nameOverride: ""
+# fullnameOverride -- specifies the full name override to be used for helm
+fullnameOverride: ""
+
+serviceAccount:
+  # serviceAccount.create -- Whether to create serviceAccounts or not
+  create: true
+  # serviceAccount.annotations -- annotations to add to each service account
+  annotations: {}
+
+rbac:
+  # rbac.create -- Whether to create RBAC or not
+  create: true
+
+features:
+  resizing:
+    # features.resizing.enabled -- specifies if resizing is enabled or not
+    enabled: true
+  snapshotting:
+    # features.snapshotting.enabled -- specifies if snapshotting is enabled or not
+    enabled: true
+  multiController:
+    # features.multiController.enabled -- specifies if multiController is enabled or not
+    enabled: false
+
+# controller -- different configuration options of controller deployment
+# @default -- `{'replicaCount':1}`
+controller:
+  replicaCount: 1
+  podSecurityContext: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# node -- different configuration options of node daemonset
+# @default -- -
+node:
+  podAnnotations: {}
+  podSecurityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# csiconfig -- backend configuration for the csi controller (see [documentation](https://github.com/Huawei/eSDK_K8S_Plugin/tree/master/docs/en))
+# @default -- `{'backends': []}`
+csiconfig:
+  backends: []
+    # Here you need to configure the list of backends that should be used by
+    # Huawei CSI. The configuration below is an example for oceanstor-nas.
+    # - name: "nfs-backend-01"
+    #   storage: "oceanstor-nas"
+    #   replicaBackend: "nfs-backend-02"
+    #   urls:
+    #     - https://storage1.example.com:8088
+    #   user:
+    #   password:
+    #   pools:
+    #     - example_pool
+    #   parameters:
+    #     portals:
+    #       - "192.0.2.116"
+    #     protocols: "nfs"
+    # - name: "nfs-backend-02"
+    #   storage: "oceanstor-nas"
+    #   replicaBackend: "nfs-backend-01"
+    #   urls:
+    #     - https://storage2.example.com:8088
+    #   user:
+    #   password:
+    #   pools:
+    #     - example_pool
+    #   parameters:
+    #     portals:
+    #       - "192.0.2.116"
+    #     protocols: "nfs"

--- a/hack/chart-testing/ct-install.yaml
+++ b/hack/chart-testing/ct-install.yaml
@@ -6,3 +6,4 @@ chart-repos:
 excluded-charts:
   - common
   - argoconfig
+  - huawei-csi-plugin


### PR DESCRIPTION
# Description

Readds the `huawei-csi-plugin` so we can add an annotation to stop artifacthub from sending us trivy mails. I'll remove it once again when trivy stops sending us security reports for the outdated, unscannable csi-attacher image.

# Issues

* https://github.com/artifacthub/hub/issues/1882

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
