### PR TITLE
fix(mopsos): use secureJson for the datasource

### DIFF
--- a/charts/mopsos/Chart.yaml
+++ b/charts/mopsos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mopsos
 description: Deploy Mopsos to a Kubernetes Cluster
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v0.3.2"
 kubeVersion: ">= 1.21.0"
 home: https://github.com/adfinis-sygroup/mopsos

--- a/charts/mopsos/README.md
+++ b/charts/mopsos/README.md
@@ -1,6 +1,6 @@
 # mopsos
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.2](https://img.shields.io/badge/AppVersion-v0.3.2-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.2](https://img.shields.io/badge/AppVersion-v0.3.2-informational?style=flat-square)
 
 Deploy Mopsos to a Kubernetes Cluster
 

--- a/charts/mopsos/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/mopsos/tests/__snapshot__/deployment_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mopsos
         app.kubernetes.io/version: v0.3.2
-        helm.sh/chart: mopsos-0.2.0
+        helm.sh/chart: mopsos-0.2.1
       name: RELEASE-NAME-mopsos
     spec:
       replicas: 1

--- a/charts/mopsos/values.yaml
+++ b/charts/mopsos/values.yaml
@@ -153,7 +153,7 @@ grafana:
   # @default -- see values.yaml
   datasources:
     datasources.yaml:
-      apiVersion: v1
+      apiVersion: 1
       datasources:
         - name: Mopsos
           uid: mopsos
@@ -164,6 +164,7 @@ grafana:
           url: ~
           database: mopsos
           user: mopsos_ro
-          password: $POSTGRESQL_RO_PASSWORD
+          secureJson:
+            password: $POSTGRESQL_RO_PASSWORD
   # -- Load mopsos secrets into grafana env
   envFromSecret: mopsos-secret


### PR DESCRIPTION
# Description

The database password needs to be in `secureJson` for it to get picked up and the datasources apiVersion is an int and not a string.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
