### PR TITLE
feat(argoconfig): allow injecting global ish annotation for app

### DIFF
--- a/charts/argoconfig/Chart.yaml
+++ b/charts/argoconfig/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argoconfig
 description: Configure Argo CD AppProjects and Applications
 type: library
-version: 0.7.6
+version: 0.8.0
 home: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/
 sources:
   - https://github.com/adfinis-sygroup/helm-charts/tree/main/charts/argoconfig

--- a/charts/argoconfig/README.md
+++ b/charts/argoconfig/README.md
@@ -1,6 +1,6 @@
 # argoconfig
 
-![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Configure Argo CD AppProjects and Applications
 
@@ -18,6 +18,12 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.adfinis.com | common | 0.0.7 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| argoconfig.application.annotations | object | `{}` | Optional annotations to add to Application metadata. |
 
 ## About this chart
 

--- a/charts/argoconfig/templates/_application.yaml
+++ b/charts/argoconfig/templates/_application.yaml
@@ -2,6 +2,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 {{ template "common.metadata" . }}
+{{ if .Values.argoconfig -}}
+{{ if .Values.argoconfig.application -}}
+{{ if .Values.argoconfig.application.annotations }}
+  annotations:
+    {{ toYaml .Values.argoconfig.application.annotations | indent 4 }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
 spec:
   project: "default"
   source: {}

--- a/charts/argoconfig/values.yaml
+++ b/charts/argoconfig/values.yaml
@@ -1,1 +1,6 @@
-# empty library chart values for testing
+# library chart values are purely for documentation purposes
+
+argoconfig:
+  application:
+    # -- Optional annotations to add to Application metadata.
+    annotations: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Introduces that ability to set a globalish annotation in our `*-apps` charts using the `argoconfig.application.annotations` key like so:

```yaml
argoconfig:
  application:
    annotations:
      foo: bar
```

I considered adding it in `common` but decided against doing so since i don't think it will add as much value there and i don't like defining `common.annotations` in a library (`common` is "reserved" for users). The `argoconfig` chart is a good fit since it has a very narrow scope anyway.

I don't think this fully replaces #643 since it doesn't allow annotating individual apps, but it will make shared labels much easier on us.

# Issues

* https://github.com/adfinis-sygroup/helm-charts/pull/643#pullrequestreview-947432741

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
