### PR TITLE
fix(argoconfig): no defaults in appProject resources

### DIFF
--- a/charts/argoconfig/Chart.yaml
+++ b/charts/argoconfig/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argoconfig
 description: Configure Argo CD AppProjects and Applications
 type: library
-version: 0.8.0
+version: 0.8.1
 home: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/
 sources:
   - https://github.com/adfinis-sygroup/helm-charts/tree/main/charts/argoconfig

--- a/charts/argoconfig/README.md
+++ b/charts/argoconfig/README.md
@@ -1,6 +1,6 @@
 # argoconfig
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Configure Argo CD AppProjects and Applications
 

--- a/charts/argoconfig/templates/_appProject.yaml
+++ b/charts/argoconfig/templates/_appProject.yaml
@@ -3,14 +3,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 {{ template "common.metadata" . }}
 spec:
-  clusterResourceWhitelist:
-    - group: '*'
-      kind: '*'
-  destinations:
-    - namespace: '*'
-      server: '*'
-  sourceRepos:
-    - '*'
+  clusterResourceWhitelist: []
+  destinations: []
+  sourceRepos: []
 {{- end }}
 {{- define "argoconfig.appProject" -}}
 {{- include "common.util.merge" (append . "argoconfig.appProject.tpl") -}}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

The `argoconfig.appProject` template currently defaults to allowing way to much. It should allow starting from a minimal set of allowlist and other rights. This removes most of the insane defaults while forcing downstream users to explicitly configure all the things.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
