### PR TITLE
feat(barman): add optional annotations to PVCs

### DIFF
--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: barman
 type: application
 description: Chart for Barman PostgreSQL Backup and Recovery Manager
-version: 0.7.2
+version: 0.8.0
 appVersion: "v2.19"
 keywords:
   - barman

--- a/charts/barman/Chart.yaml
+++ b/charts/barman/Chart.yaml
@@ -14,6 +14,6 @@ sources:
   - https://github.com/ubc/barman-docker
   - https://github.com/adfinis-sygroup/helm-charts/tree/main/charts/barman
 maintainers:
-  - name: adfinis
+  - name: adfinis-sygroup
     email: support@adfinis.com
     url: https://adfinis.com

--- a/charts/barman/README.md
+++ b/charts/barman/README.md
@@ -1,6 +1,6 @@
 # barman
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.19](https://img.shields.io/badge/AppVersion-v2.19-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.19](https://img.shields.io/badge/AppVersion-v2.19-informational?style=flat-square)
 
 Chart for Barman PostgreSQL Backup and Recovery Manager
 
@@ -55,10 +55,12 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | image.repository | string | `"ubcctlt/barman"` | Container image to deploy |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart version. |
 | persistence.data.accessMode | string | `"ReadWriteOnce"` | Access mode for persistent storage |
+| persistence.data.annotations | object | `{}` | Add annotations to backup data PVC |
 | persistence.data.enabled | bool | `true` | Enable persistent storage for backup data |
 | persistence.data.size | string | `"20Gi"` | Size of storage volume |
 | persistence.data.storageClass | string | `""` | Storage class |
 | persistence.recover.accessMode | string | `"ReadWriteOnce"` | Access mode for persistent storage |
+| persistence.recover.annotations | object | `{}` | Add annotations to recovery PVC |
 | persistence.recover.enabled | bool | `false` | Enable persistent storage for recovery |
 | persistence.recover.size | string | `"4Gi"` | Size of storage volume |
 | persistence.recover.storageClass | string | `""` | Storage class |

--- a/charts/barman/templates/pvc.yaml
+++ b/charts/barman/templates/pvc.yaml
@@ -2,9 +2,13 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: {{ include "barman.fullname" . }}-data
   labels:
     {{- include "barman.labels" . | nindent 4 }}
-  name: {{ include "barman.fullname" . }}-data
+  {{- with .Values.persistence.data.annotations }}
+  annotations:
+    {{ . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
   - {{ .Values.persistence.data.accessMode | quote }}
@@ -20,9 +24,13 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: {{ include "barman.fullname" . }}-recover
   labels:
     {{- include "barman.labels" . | nindent 4 }}
-  name: {{ include "barman.fullname" . }}-recover
+  {{- with .Values.persistence.recover.annotations }}
+  annotations:
+    {{ . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
   - {{ .Values.persistence.recover.accessMode | quote }}

--- a/charts/barman/values.yaml
+++ b/charts/barman/values.yaml
@@ -62,6 +62,8 @@ persistence:
     size: 20Gi
     # -- Storage class
     storageClass: ""
+    # -- Add annotations to backup data PVC
+    annotations: {}
   recover:
     # -- Enable persistent storage for recovery
     enabled: false
@@ -71,6 +73,8 @@ persistence:
     size: 4Gi
     # -- Storage class
     storageClass: ""
+    # -- Add annotations to recovery PVC
+    annotations: {}
 
 rbac:
   # -- Whether to create RBAC or not


### PR DESCRIPTION
# Description

Allow specifying annotations on both the backup and recovery PVC. 

This can be used to set any annotations on the PVC (ie. a resource policy as described in #644

```yaml
persistence:
  data:
    annotations:
      helm.sh/resource-policy: keep
```

# Issues

* Fixes #644 

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
