### PR TITLE
fix(security-apps): remove trailing slash in neuvector chart repo

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
-version: 0.47.0
+version: 0.47.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/main/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.47.0](https://img.shields.io/badge/Version-0.47.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.47.1](https://img.shields.io/badge/Version-0.47.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -70,14 +70,14 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | neuvector.chart | string | `"core"` | Chart |
 | neuvector.destination.namespace | string | `"infra-neuvector"` | Namespace |
 | neuvector.enabled | bool | `false` | Enable neuvector |
-| neuvector.repoURL | string | [repo](https://neuvector.github.io/neuvector-helm/) | Repo URL |
+| neuvector.repoURL | string | [repo](https://neuvector.github.io/neuvector-helm) | Repo URL |
 | neuvector.targetRevision | string | `"2.2.*"` | [neuvector/core Helm chart](https://github.com/neuvector/neuvector-helm/tree/master/charts/core) version |
 | neuvector.values | object | [upstream values](https://github.com/neuvector/neuvector-helm/blob/master/charts/core/values.yaml) | Helm values |
 | neuvectorMonitor | object | - | [NeuVector monitor](https://github.com/neuvector/neuvector-helm/tree/master/charts/monitor) ([example](./example/neuvector.yaml)) |
 | neuvectorMonitor.chart | string | `"monitor"` | Chart |
 | neuvectorMonitor.destination.namespace | string | `"infra-neuvector"` | Namespace |
 | neuvectorMonitor.enabled | bool | `false` | Enable neuvector/monitor |
-| neuvectorMonitor.repoURL | string | [repo](https://neuvector.github.io/neuvector-helm/) | Repo URL |
+| neuvectorMonitor.repoURL | string | [repo](https://neuvector.github.io/neuvector-helm) | Repo URL |
 | neuvectorMonitor.targetRevision | string | `"2.2.*"` | [neuvector/monitor Helm chart](https://github.com/neuvector/neuvector-helm/tree/master/charts/monitor) version |
 | neuvectorMonitor.values | object | [upstream values](https://github.com/neuvector/neuvector-helm/blob/master/charts/monitor/values.yaml) | Helm values |
 | secretsStoreCsiDriver | object | - | [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) ([example](./examples/secrets-store-csi-driver.yaml)) |

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -196,8 +196,8 @@ neuvector:
     # -- Namespace
     namespace: "infra-neuvector"
   # -- Repo URL
-  # @default -- [repo](https://neuvector.github.io/neuvector-helm/)
-  repoURL: "https://neuvector.github.io/neuvector-helm/"
+  # @default -- [repo](https://neuvector.github.io/neuvector-helm)
+  repoURL: "https://neuvector.github.io/neuvector-helm"
   # -- Chart
   chart: "core"
   # -- [neuvector/core Helm chart](https://github.com/neuvector/neuvector-helm/tree/master/charts/core) version
@@ -216,8 +216,8 @@ neuvectorMonitor:
     # -- Namespace
     namespace: "infra-neuvector"
   # -- Repo URL
-  # @default -- [repo](https://neuvector.github.io/neuvector-helm/)
-  repoURL: "https://neuvector.github.io/neuvector-helm/"
+  # @default -- [repo](https://neuvector.github.io/neuvector-helm)
+  repoURL: "https://neuvector.github.io/neuvector-helm"
   # -- Chart
   chart: "monitor"
   # -- [neuvector/monitor Helm chart](https://github.com/neuvector/neuvector-helm/tree/master/charts/monitor) version


### PR DESCRIPTION
# Description

Removes the trailing slash in the NeuVector Helm chart repos since those always clash with appprojects.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
