### PR TITLE
fix(tracing-apps): upgrade opentelemetry-collector from 0.20.1 to 0.20.2

### DIFF
--- a/charts/tracing-apps/Chart.yaml
+++ b/charts/tracing-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tracing-apps
 description: Argo CD app-of-apps config for tracing applications
 type: application
-version: 0.14.0
+version: 0.14.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/main/charts/tracing-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/tracing-apps/README.md
+++ b/charts/tracing-apps/README.md
@@ -1,6 +1,6 @@
 # tracing-apps
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for tracing applications
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | opentelemetryCollector.destination.namespace | string | `"infra-otel-operator"` | Namespace |
 | opentelemetryCollector.enabled | bool | `false` | Enable otel-exporter |
 | opentelemetryCollector.repoURL | string | [repo](https://open-telemetry.github.io/opentelemetry-helm-charts) | Repo URL |
-| opentelemetryCollector.targetRevision | string | `"0.20.1"` | [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) |
+| opentelemetryCollector.targetRevision | string | `"0.20.2"` | [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) |
 | opentelemetryCollector.values | object | [upstream values](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml) | Helm values |
 
 ## About this chart

--- a/charts/tracing-apps/values.yaml
+++ b/charts/tracing-apps/values.yaml
@@ -33,7 +33,7 @@ opentelemetryCollector:
   # -- Chart
   chart: "opentelemetry-collector"
   # -- [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector)
-  targetRevision: "0.20.1"
+  targetRevision: "0.20.2"
   # -- Helm values
   # @default -- [upstream values](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

'''opentelemetry-collector''' 0.20.2 adds support for both `policy/v1` and `policy/v1beta1` in PodDisruptionBudget resources.

# Issues

* https://github.com/open-telemetry/opentelemetry-helm-charts/pull/241

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
