### PR TITLE
feat(infra-apps): udpate velero from 2.29 to 2.30

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.108.0
+version: 0.109.0
 home: https://github.com/adfinis-sygroup/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.108.0](https://img.shields.io/badge/Version-0.108.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.109.0](https://img.shields.io/badge/Version-0.109.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -110,7 +110,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | velero.destination.namespace | string | `"infra-velero"` | Namespace |
 | velero.enabled | bool | `false` | Enable Velero |
 | velero.repoURL | string | [repo](https://vmware-tanzu.github.io/helm-charts) | Repo URL |
-| velero.targetRevision | string | `"2.29.*"` | [Velero Helm chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero) |
+| velero.targetRevision | string | `"2.30.*"` | [Velero Helm chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero) |
 | velero.values | object | [upstream values](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml) | Helm values |
 
 ## About this chart

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -199,7 +199,7 @@ velero:
   # -- Chart
   chart: velero
   # -- [Velero Helm chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero)
-  targetRevision: 2.29.*
+  targetRevision: 2.30.*
   # -- Helm values
   # @default -- [upstream values](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Bumps Velero to the 1.9.0 release. 
* Improve the CSI snapshotter and bump it's api to v1 (needs k8s 1.20+)
* Upgrade integrated Restic version and add skip TLS validation in Restic command
* Add `--existing-resource-policy=update` to allow updating existing resources in a restore
* Allow configuring if status should be restored with `restoreStatus`

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->
* https://github.com/vmware-tanzu/helm-charts/pull/383
* https://github.com/vmware-tanzu/helm-charts/pull/384
* https://github.com/vmware-tanzu/velero/releases/tag/v1.9.0

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [ ] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
