### PR TITLE
fix(security-apps): use existing stackrox chart version

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
-version: 0.53.0
+version: 0.53.1
 home: https://github.com/adfinis-sygroup/helm-charts/tree/main/charts/security-apps
 sources:
   - https://github.com/adfinis-sygroup/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.53.0](https://img.shields.io/badge/Version-0.53.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.53.1](https://img.shields.io/badge/Version-0.53.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -87,19 +87,19 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | secretsStoreCsiDriver.repoURL | string | [repo](https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts) | Repo URL |
 | secretsStoreCsiDriver.targetRevision | string | `"1.1.*"` | [secrets-store-csi-driver Helm chart](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver) version |
 | secretsStoreCsiDriver.values | object | [upstream values](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/values.yaml) | Helm values |
-| stackroxCentralServices | object | `{"chart":"central-services","destination":{"namespace":"infra-stackrox"},"enabled":false,"name":"stackrox-central-services","repoURL":"https://charts.stackrox.io","targetRevision":"70.0.0","values":{}}` | [StackRox central-services](https://www.stackrox.io/) ([example/stackrox.yaml)) |
-| stackroxCentralServices.chart | string | `"central-services"` | Chart |
+| stackroxCentralServices | object | - | [StackRox central-services](https://www.stackrox.io/) ([example/stackrox.yaml)) |
+| stackroxCentralServices.chart | string | `"stackrox-central-services"` | Chart |
 | stackroxCentralServices.destination.namespace | string | `"infra-stackrox"` | Namespace |
 | stackroxCentralServices.enabled | bool | `false` | Enable StackRox central-services |
 | stackroxCentralServices.repoURL | string | [repo](https://charts.stackrox.io) | Repo URL |
-| stackroxCentralServices.targetRevision | string | `"70.0.0"` | [stackrox/central-services Helm chart](https://github.com/stackrox/helm-charts/tree/main/opensource) version |
+| stackroxCentralServices.targetRevision | string | `"70.1.0"` | [stackrox/central-services Helm chart](https://github.com/stackrox/helm-charts/tree/main/opensource) version |
 | stackroxCentralServices.values | object | [upstream values](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/stackrox-central/values.yaml) | Helm values |
-| stackroxSecuredClusterServices | object | `{"chart":"secured-cluster-services","destination":{"namespace":"infra-stackrox"},"enabled":false,"name":"stackrox-secured-cluster-services","repoURL":"https://charts.stackrox.io","targetRevision":"70.0.0","values":{}}` | [StackRox secured-cluster-services](https://www.stackrox.io/) ([example/stackrox.yaml)) |
-| stackroxSecuredClusterServices.chart | string | `"secured-cluster-services"` | Chart |
+| stackroxSecuredClusterServices | object | - | [StackRox secured-cluster-services](https://www.stackrox.io/) ([example/stackrox.yaml)) |
+| stackroxSecuredClusterServices.chart | string | `"stackrox-secured-cluster-services"` | Chart |
 | stackroxSecuredClusterServices.destination.namespace | string | `"infra-stackrox"` | Namespace |
 | stackroxSecuredClusterServices.enabled | bool | `false` | Enable StackRox secured-cluster-services |
 | stackroxSecuredClusterServices.repoURL | string | [repo](https://charts.stackrox.io) | Repo URL |
-| stackroxSecuredClusterServices.targetRevision | string | `"70.0.0"` | [stackrox/secured-cluster-services Helm chart](https://github.com/stackrox/helm-charts/tree/main/opensource) version |
+| stackroxSecuredClusterServices.targetRevision | string | `"70.1.0"` | [stackrox/secured-cluster-services Helm chart](https://github.com/stackrox/helm-charts/tree/main/opensource) version |
 | stackroxSecuredClusterServices.values | object | [upstream values](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl) | Helm values |
 | vault | object | - | [vault](https://github.com/hashicorp/vault/) ([example](./examples/vault.yaml)) |
 | vault.chart | string | `"vault"` | Chart |

--- a/charts/security-apps/examples/stackrox.yaml
+++ b/charts/security-apps/examples/stackrox.yaml
@@ -3,6 +3,11 @@
 stackroxCentralServices:
   enabled: true
   values:
+    allowNonstandardNamespace: true
+    imagePullSecrets:
+      allowNone: true
+    image:
+      registry: quay.io/stackrox-io
     env:
       openshift: false
       istio: false
@@ -10,6 +15,12 @@ stackroxCentralServices:
 stackroxSecuredClusterServices:
   enabled: true
   values:
+    allowNonstandardNamespace: true
+    mainImagePullSecrets:
+      allowNone: true
+    collectorImagePullSecrets:
+      allowNone: true
+    clusterName: cluster-name
     endpoint:
       central: "central.infra-stackrox.svc:443"
       advertised: "sensor.infra-stackrox.svc:443"

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -227,6 +227,7 @@ neuvectorMonitor:
   values: {}
 
 # -- [StackRox central-services](https://www.stackrox.io/) ([example/stackrox.yaml))
+# @default -- -
 stackroxCentralServices:
   # -- Enable StackRox central-services
   enabled: false
@@ -238,14 +239,15 @@ stackroxCentralServices:
   # @default -- [repo](https://charts.stackrox.io)
   repoURL: https://charts.stackrox.io
   # -- Chart
-  chart: central-services
+  chart: stackrox-central-services
   # -- [stackrox/central-services Helm chart](https://github.com/stackrox/helm-charts/tree/main/opensource) version
-  targetRevision: 70.0.0
+  targetRevision: 70.1.0
   # -- Helm values
   # @default -- [upstream values](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/stackrox-central/values.yaml)
   values: {}
 
 # -- [StackRox secured-cluster-services](https://www.stackrox.io/) ([example/stackrox.yaml))
+# @default -- -
 stackroxSecuredClusterServices:
   # -- Enable StackRox secured-cluster-services
   enabled: false
@@ -257,9 +259,9 @@ stackroxSecuredClusterServices:
   # @default -- [repo](https://charts.stackrox.io)
   repoURL: https://charts.stackrox.io
   # -- Chart
-  chart: secured-cluster-services
+  chart: stackrox-secured-cluster-services
   # -- [stackrox/secured-cluster-services Helm chart](https://github.com/stackrox/helm-charts/tree/main/opensource) version
-  targetRevision: 70.0.0
+  targetRevision: 70.1.0
   # -- Helm values
   # @default -- [upstream values](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl)
   values: {}


### PR DESCRIPTION
# Description

The 70.0.0 version that is commited to the stackrox helm repo isn't what is actually published to the chart repo so we  update our deployment to use the published version. Also updates the examples with what i've learned about stackrox so far.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
