### PR TITLE
fix(openshift-etcd-backup): Update to 1.9.6 and fix prometheus alerting rule

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.9.5
-appVersion: v1.9.5
+version: 1.9.6
+appVersion: v1.9.6
 keywords:
   - openshift-etcd-backup
   - openshift
@@ -21,9 +21,9 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        upgrade openshift-etcd-backup image to v1.9.5
+        upgrade openshift-etcd-backup image to v1.9.6
+
+        * fixed prometheus alert
       links:
-        - name: openshift-etcd-backup release v1.9.4
-          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.4
-        - name: openshift-etcd-backup release v1.9.5
-          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.5
+        - name: openshift-etcd-backup release v1.9.6
+          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.6

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.9.5](https://img.shields.io/badge/Version-1.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.5](https://img.shields.io/badge/AppVersion-v1.9.5-informational?style=flat-square)
+![Version: 1.9.6](https://img.shields.io/badge/Version-1.9.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.6](https://img.shields.io/badge/AppVersion-v1.9.6-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 

--- a/charts/openshift-etcd-backup/templates/prometheusrule.yaml
+++ b/charts/openshift-etcd-backup/templates/prometheusrule.yaml
@@ -9,7 +9,7 @@ spec:
     rules:
     - alert: EtcdBackupCronJobStatusFailed
       expr: |
-        kube_job_status_succeeded{namespace="{{ .Release.Namespace }}"} == 0
+        kube_job_status_failed{namespace="{{ .Release.Namespace }}"} > 0
       labels:
         severity: critical
 {{- end }}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Fixes the included alerting rule so it doesn't do a false positive alert while the job is running.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
