### PR TITLE
chore(tracing-apps): Bumping opentelemetryCollector chart to 0.134.0

### DIFF
--- a/charts/tracing-apps/Chart.yaml
+++ b/charts/tracing-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tracing-apps
 description: Argo CD app-of-apps config for tracing applications
 type: application
-version: 0.32.1
+version: 0.33.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/tracing-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -18,15 +18,18 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        feat: Updating jaegerOperator Chart form 2.54.0 to 2.57.0
-        Includes upgrade jaeger from 1.57.0 to 1.61.0
+        chore: Updating opentelemetry-collector Chart form to 0.134.0
+          - bump collector to version 0.135.0
+          - Adding runtimeClassName to pod spec
+          - Add missing Kubernetes recommended labels
+          - Kernel and fuse mount options per cluster
       links:
-        - name: Release of jaeger v1.58.0
-          url: https://github.com/jaegertracing/jaeger/releases/tag/v1.58.0
-        - name: Release of jaeger v1.58.1
-          url: https://github.com/jaegertracing/jaeger/releases/tag/v1.58.1
-        - name: Release of jaeger v1.59.0
-          url: https://github.com/jaegertracing/jaeger/releases/tag/v1.59.0
+        - name: Release of opentelemetry-collector-0.134.0
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-collector-0.134.0
+        - name:  opentelemetry-collector-0.133.1
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-collector-0.133.1
+        - name: opentelemetry-collector-0.130.2
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-collector-0.130.2
         - name: Release of jaeger v1.60.0
           url: https://github.com/jaegertracing/jaeger/releases/tag/v1.60.0
         - name: Release of jaeger v1.61.0

--- a/charts/tracing-apps/README.md
+++ b/charts/tracing-apps/README.md
@@ -1,6 +1,6 @@
 # tracing-apps
 
-![Version: 0.32.1](https://img.shields.io/badge/Version-0.32.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for tracing applications
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | opentelemetryCollector.destination.namespace | string | `"infra-otel-operator"` | Namespace |
 | opentelemetryCollector.enabled | bool | `false` | Enable otel-exporter |
 | opentelemetryCollector.repoURL | string | [repo](https://open-telemetry.github.io/opentelemetry-helm-charts) | Repo URL |
-| opentelemetryCollector.targetRevision | string | `"0.127.2"` | [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) |
+| opentelemetryCollector.targetRevision | string | `"0.134.0"` | [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) |
 | opentelemetryCollector.values | object | [upstream values](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml) | Helm values |
 
 ## About this chart

--- a/charts/tracing-apps/values.yaml
+++ b/charts/tracing-apps/values.yaml
@@ -33,7 +33,7 @@ opentelemetryCollector:
   # -- Chart
   chart: "opentelemetry-collector"
   # -- [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector)
-  targetRevision: "0.127.2"
+  targetRevision: "0.134.0"
   # -- Helm values
   # @default -- [upstream values](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
 Bumping opentelemetryCollector chart to 0.134.0
Changes:
 - bump collector to version 0.135.0
 - Adding runtimeClassName to pod spec
 - Add missing Kubernetes recommended labels
 - Kernel and fuse mount options per cluster

I will be testing the changes on AKS INT next Tuesday.

# Issues
https://github.com/adfinis/helm-charts/issues/1469
<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
