### PR TITLE
chore(misc-apps): Bumping keda chart to 2.17.2

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
-version: 0.56.0
+version: 0.57.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/misc-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -19,14 +19,26 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        chore: Upgraded goldilocks chart from 9.0.1 to 10.1.0
+        chore: Upgraded Keda chart from 2.14.2 to 2.17.2
 
-        - move the metrics-server sub-chart from bitnami to kubernetes-sigs
-        - fixed insecure tls for metrics server
-        - Added support for additional RBAC rules in dashboard-clusterrole.yaml.
-        - Implemented extra ClusterRoleBindings in dashboard-clusterrolebinding.yaml
-        - updated goldilocks to 4.14.1
+        - Bumped Keda to v2.17.0
+        - improved security with stricter RBAC
+        - improved reliability of cer Renewals
+        - added option to disable the creation of legacy Docker service links
+        - fixed service account token bug.
 
       links:
-        - name: Chart Page with release notes
-          url: https://artifacthub.io/packages/helm/fairwinds-stable/goldilocks
+        - name: v2.17.2 release notes
+          url: https://github.com/kedacore/charts/releases/tag/v2.17.2
+        - name: v2.17.1 release notes
+          url: https://github.com/kedacore/charts/releases/tag/v2.17.1
+        - name: v2.16.1 release notes
+          url: https://github.com/kedacore/charts/releases/tag/v2.16.1
+        - name: v2.16.0 release notes
+          url: https://github.com/kedacore/charts/releases/tag/v2.16.0
+        - name: v2.15.2 release notes
+          url: https://github.com/kedacore/charts/releases/tag/v2.15.2
+        - name: v2.15.1 release notes
+          url: https://github.com/kedacore/charts/releases/tag/v2.15.1
+        - name: v2.14.3 release notes
+          url: https://github.com/kedacore/charts/releases/tag/v2.14.3

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.56.0](https://img.shields.io/badge/Version-0.56.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.57.0](https://img.shields.io/badge/Version-0.57.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -67,7 +67,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | keda.destination.namespace | string | `"infra-keda"` | Namespace |
 | keda.enabled | bool | `false` | Enable KEDA |
 | keda.repoURL | string | [repo](https://kedacore.github.io/charts) | Repo URL |
-| keda.targetRevision | string | `"2.14.2"` | [keda Helm chart](https://github.com/kedacore/charts/tree/main/keda/) version |
+| keda.targetRevision | string | `"2.17.2"` | [keda Helm chart](https://github.com/kedacore/charts/tree/main/keda/) version |
 | keda.values | object | [upstream values](https://github.com/kedacore/charts/blob/main/keda/values.yaml) | Helm values |
 | metallb | object | - | [metallb](https://github.com/metallb/metallb) ([example](./examples/metallb.yaml)) |
 | metallb.chart | string | `"metallb"` | Chart |

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -158,7 +158,7 @@ keda:
   # -- Chart
   chart: keda
   # -- [keda Helm chart](https://github.com/kedacore/charts/tree/main/keda/) version
-  targetRevision: 2.14.2
+  targetRevision: 2.17.2
   # -- Helm values
   # @default -- [upstream values](https://github.com/kedacore/charts/blob/main/keda/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description
Upgraded keda chart to 2.17.2

 - Bumped Keda to v2.17.0
 - improved security with stricter RBAC
 - improved reliability of cer Renewals
 - added option to disable the creation of legacy Docker service links
 - fixed service account token bug.

I will be testing the changes on AKS INT.
<!-- Describe the changes your PR introduces here. -->

# Issues
https://github.com/adfinis/helm-charts/issues/1447
<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
