### PR TITLE
chore(CODEOWNERS): remove timed entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,5 @@
 /charts/vault-auth                  @adfinis/helm-charts @eyenx
 /charts/vault-monitoring            @adfinis/helm-charts @pree @eyenx
 /charts/mopsos                      @adfinis/helm-charts @hairmare @eyenx
-/charts/timed                       @adfinis/helm-charts @adfinis/dev-devops
 /charts/osschallenge                @adfinis/helm-charts @adfinis/dev-devops
 /charts/hedgedoc                    @adfinis/helm-charts @altesockensuppe @gianklug


### PR DESCRIPTION
the timed chart was moved into the [timed monorepo](https://github.com/adfinis/timed/) quite some time ago

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

remove `charts/timed` from codeowners because the chart is no longer in this repository
 
<!-- Describe the changes your PR introduces here. -->

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
