### PR TITLE
chore(infra-apps): Bump kubePrometheusStack to 80.9.2

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.256.0
+version: 0.257.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -19,29 +19,6 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        fix: update certManager to 1.19.2
-
-        - Fixes for various CVEs
-        - Updated ACME client
-        - Add IPv6 rules to the default network policy
-        - Add global.nodeSelector to helm chart
-        - Add a feature gate to default to Ingress pathType Exact in ACME HTTP01 Ingress challenge solvers.
-        - Add generated applyconfigurations allowing clients to make type-safe server-side apply requests for cert-manager resources.
-        - Added API defaults to issuer references group (cert-manager.io) and kind (Issuer)
-        - Added certmanager_certificate_challenge_status Prometheus metric.
-        - Added protocol field for rfc2136 DNS01 provider
-        - The CAInjectorMerging feature has been promoted to BETA and is now enabled by default
-        - Updated certificate metrics to the collector approach
-        - ACME: Increased challenge authorization timeout to 2 minutes to fix error waiting for authorization
-        - Increase maximum sizes of PEM certificates and chain
-
-
-      links:
-        - name: v1.19.2 Release
-          url: https://github.com/cert-manager/cert-manager/releases/tag/v1.19.2
-        - name: v1.18.4 Release
-          url: https://github.com/cert-manager/cert-manager/releases/tag/v1.18.4
-        - name: v1.19.1 Release
-          url: https://github.com/cert-manager/cert-manager/releases/tag/v1.19.1
-        - name: v1.19.0 Release
-          url: https://github.com/cert-manager/cert-manager/releases/tag/v1.19.0
+        Update from kube-prometheus-stack v79.9.0 to v80.9.2
+        - Update etcd image digest bump in v80.9.0
+        - Update kube-prometheus-stack dependencies non-major updates

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.256.0](https://img.shields.io/badge/Version-0.256.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.257.0](https://img.shields.io/badge/Version-0.257.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -72,7 +72,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
 | kubePrometheusStack.syncPolicy.syncOptions[0] | string | `"ServerSideApply=true"` | enable server-side-apply for KPS since it get's rid of having to manually sync/replace resources |
-| kubePrometheusStack.targetRevision | string | `"79.9.0"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"80.9.2"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/kubereboot/kured) |
 | kured.annotations | object | `{}` | Annotations for Kured app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -131,7 +131,7 @@ kubePrometheusStack:
   # -- Chart
   chart: kube-prometheus-stack
   # -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: 79.9.0
+  targetRevision: 80.9.2
   syncPolicy:
     syncOptions:
       # -- enable server-side-apply for KPS since it get's rid of having to manually sync/replace resources


### PR DESCRIPTION

# Description

Update from kube-prometheus-stack v79.9.0 to v80.9.2
  - Update etcd image digest bump in v80.9.0
  - Update kube-prometheus-stack dependencies non-major updates

# Issues

n/a

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
