### PR TITLE
chore(ingress-nginx): bump to 4.14.3

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.260.2
+version: 0.260.3
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -15,15 +15,15 @@ dependencies:
     version: 0.9.1
     repository: https://charts.adfinis.com
 annotations:
-  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        Update argocd from 3.2.5 to 3.3.0
-        * fixes #1664
-        * helm chart version from 9.3.4 to 9.3.7
+        Update ingress-nginx from 4.14.1 to 4.14.3
+        * fixes #1666
+        * controller version from 1.14.1 to 1.14.3
       links:
-        - name: argo-cd release notes v3.3.0
-          url: https://github.com/argoproj/argo-cd/releases/tag/v3.3.0
-        - name: argo-cd upgrade guide v3.2-v3.3
-          url: https://argo-cd.readthedocs.io/en/latest/operator-manual/upgrading/3.2-3.3/
+        - name: ingress-nginx controller release notes v1.14.3
+          url: https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.14.3
+        - name: ingress-nginx helm chart release notes v4.14.3
+          url: https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.14.3

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.260.2](https://img.shields.io/badge/Version-0.260.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.260.3](https://img.shields.io/badge/Version-0.260.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -62,7 +62,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | ingressNginx.destination.namespace | string | `"infra-ingress"` | Namespace |
 | ingressNginx.enabled | bool | `false` | Configure nginx-ingress |
 | ingressNginx.repoURL | string | [repo](https://kubernetes.github.io/ingress-nginx) | Repo URL |
-| ingressNginx.targetRevision | string | `"4.14.1"` | [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) version |
+| ingressNginx.targetRevision | string | `"4.14.3"` | [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) version |
 | ingressNginx.values | object | [upstream values](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml) | Helm values |
 | kubeEventExporter | object | DEPRECATED | [kubernetes-event-exporter](https://github.com/resmoio/kubernetes-event-exporter) is DEPRECATED, use "otel-collector" instead |
 | kubePrometheusStack | object | [example](./examples/prometheus.yaml) | [prometheus-operator](https://github.com/coreos/prometheus-operator) |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -109,7 +109,7 @@ ingressNginx:
   # -- Chart
   chart: ingress-nginx
   # -- [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) version
-  targetRevision: 4.14.1
+  targetRevision: 4.14.3
   # -- Helm values
   # @default -- [upstream values](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Bump ingress-nginx chart to 4.14.3 to fix multiple CVEs:

- https://github.com/kubernetes/kubernetes/issues/136677
- https://github.com/kubernetes/kubernetes/issues/136678
- https://github.com/kubernetes/kubernetes/issues/136679
- https://github.com/kubernetes/kubernetes/issues/136680

# Issues

https://github.com/adfinis/helm-charts/issues/1666

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

