### PR TITLE
chore: fix typo causing updated snap files to be considered changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
-# we use .gitattributes for linguist for hinting, see:
-# <https://github.com/github/linguist/blob/master/docs/overrides.md>
+# we use .gitattributes for linguist hinting, see:
+# <https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github>
 
 # generated files
-README.md linguist-generated=true
-charts/*/charts/README.md linguist-generated=true
-charts/*/test//__snapshot__/*.snap linguist-generated=true
+README.md linguist-generated
+charts/*/charts/README.md linguist-generated
+charts/*/tests/__snapshot__/*.snap linguist-generated
 
 # override smarty/mustache language
 charts/*/templates/*.tpl linguist-language=Go


### PR DESCRIPTION
# Description

While reviewing #1730 I was wondering if we should exclude updates in `*.snap` files from the diff and while looking at `.gitattributes` I realized that this was probably just down to a typo.

# Issues

n/a

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released