### PR TITLE
feat(hedgedoc): bump to 1.10.8 and replace Bitnami postgresql with CloudPirates postgres

### DIFF
--- a/charts/hedgedoc/Chart.lock
+++ b/charts/hedgedoc/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 12.2.1
-digest: sha256:ca28b52822f020d68ca02abf492be4e53188d5e68a2190e4fc78c0b37ae4aa65
-generated: "2023-02-23T13:45:02.288748722+01:00"
+- name: postgres
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.19.5
+digest: sha256:d535bb280eddd383cc3e6ecfb7da3696bdd4353ffe552fa20c8fdbaee7674505
+generated: "2026-06-02T16:28:57.599685825+02:00"

--- a/charts/hedgedoc/Chart.yaml
+++ b/charts/hedgedoc/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: hedgedoc
 description: Chart for HedgeDoc, a fork of CodiMD
 type: application
-version: 0.5.4
-appVersion: "1.10.3"
+version: 0.6.0
+appVersion: "1.10.8"
 icon: https://raw.githubusercontent.com/hedgedoc/hedgedoc-logo/main/LOGOTYPE/PNG/HedgeDoc-Logo%201.png
 sources:
   - https://github.com/hedgedoc/hedgedoc
@@ -13,14 +13,20 @@ maintainers:
     email: "support@adfinis.com"
     url: "https://adfinis.com"
 dependencies:
-  - name: postgresql
-    version: ~12.2.1
+  - name: postgres
+    alias: postgresql
+    version: ~0.19.5
     condition: postgresql.enabled
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/cloudpirates
 annotations:
   artifacthub.io/images: |
     - name: hedgedoc
-      image: quay.io/hedgedoc/hedgedoc:1.10.3
+      image: quay.io/hedgedoc/hedgedoc:1.10.8
   artifacthub.io/changes: |
     - kind: changed
-      description: Bumped hedgedoc image tag to 1.10.3
+      description: Bumped hedgedoc to 1.10.8
+      links:
+        - name: GitHub Release
+          url: https://github.com/hedgedoc/hedgedoc/releases/tag/1.10.8
+    - kind: changed
+      description: Replaced Bitnami postgresql dependency with CloudPirates postgres (OCI)

--- a/charts/hedgedoc/README.md
+++ b/charts/hedgedoc/README.md
@@ -1,6 +1,6 @@
 # hedgedoc
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.3](https://img.shields.io/badge/AppVersion-1.10.3-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.8](https://img.shields.io/badge/AppVersion-1.10.8-informational?style=flat-square)
 
 Chart for HedgeDoc, a fork of CodiMD
 
@@ -15,7 +15,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | ~12.2.1 |
+| oci://registry-1.docker.io/cloudpirates | postgresql(postgres) | ~0.19.5 |
 
 ## Values
 
@@ -43,7 +43,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| postgresql | object | `{"auth":{"database":"hedgedoc","password":"hedgedoc","username":"hedgedoc","volumePermissions":{"enabled":true}},"enabled":true}` | PostgreSQL chart configuration  Reference: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml  If you want to use external database, just set postgresql.enabled to false  |
+| postgresql | object | `{"auth":{"database":"hedgedoc","password":"hedgedoc","username":"hedgedoc"},"enabled":true,"nameOverride":"postgresql"}` | PostgreSQL chart configuration  Reference: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml  If you want to use external database, just set postgresql.enabled to false  |
 | prometheus.enabled | bool | `false` | Enable Prometheus integration |
 | prometheus.extraAnnotations | object | `{}` | Annotations to add to all Prometheus integration resources |
 | prometheus.extraLabels | object | `{}` | Labels to add to all Prometheus integration resources |

--- a/charts/hedgedoc/values.yaml
+++ b/charts/hedgedoc/values.yaml
@@ -268,12 +268,11 @@ affinity: {}
 #
 postgresql:
   enabled: true
+  nameOverride: postgresql
   auth:
     username: hedgedoc
     password: hedgedoc
     database: hedgedoc
-    volumePermissions:
-      enabled: true
 
 
 # -- Configure your external database here


### PR DESCRIPTION
Bumps HedgeDoc from 1.10.3 to 1.10.8 and replaces the Bitnami postgresql chart with the CloudPirates postgres chart.

## Description

- Updated `appVersion` to `1.10.8`
- Bumped chart version to `0.6.0`
- Replaced `bitnami/postgresql ~12.2.1` with `cloudpirates/postgres ~0.19.5` (OCI)
- Used `alias: postgresql` to keep the values key backwards compatible
- Added `nameOverride: postgresql` to keep the service hostname (`<release>-postgresql`) stable
- Removed Bitnami-specific `volumePermissions` key from default values

## References

- https://github.com/hedgedoc/hedgedoc/releases/tag/1.10.8
- https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres

## Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I updated the version in Chart.yaml
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the example /adfinis/helm-charts/blob/main/docs/development.md#Changelog in the documentation.
- [x] I updated applicable README.md files using `pre-commit run`
- [x] I documented any high-level concepts I'm introducing in `docs/`
- [x] CI is currently green and this is ready for review
- [x] I am ready to test changes after they are applied and released